### PR TITLE
Fix deploy: use sudo su syntax matching sudoers entries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
                 ;;
               update)
                 echo "Updating moltbot..."
-                sudo -u ${{ env.MOLTBOT_USER }} -i npm update -g moltbot || true
+                sudo su - ${{ env.MOLTBOT_USER }} -c "npm update -g moltbot" || true
                 sudo systemctl restart moltbot-gateway || echo "Service not yet configured"
                 ;;
               restart)
@@ -85,9 +85,9 @@ jobs:
             # Show status
             echo ""
             echo "=== Deployment Complete ==="
-            sudo systemctl status moltbot-gateway --no-pager || true
+            sudo systemctl status moltbot-gateway || true
             echo ""
-            sudo -u ${{ env.MOLTBOT_USER }} -i moltbot --version || echo "Moltbot not yet installed"
+            sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot --version" || echo "Moltbot not yet installed"
 
   health-check:
     name: Health Check


### PR DESCRIPTION
The deploy workflow used `sudo -u moltbot -i` which is not permitted
by the sudoers file (only `sudo su - moltbot` is allowed). This caused
the npm update to fail silently, leaving the service unable to start,
which the health check then correctly flagged.

Changes:
- deploy.yml: Replace `sudo -u moltbot -i` with `sudo su - moltbot -c`
- deploy.yml: Remove --no-pager from systemctl status (not in sudoers)
- setup-server.sh: Resolve binary paths dynamically to handle /bin vs
  /usr/bin symlink differences across distros
- setup-server.sh: Add wildcard to systemctl status entry, add
  daemon-reload entry

https://claude.ai/code/session_01Ft4uJyHegpE8gAaJw3eHZQ