### PR TITLE
Fix gateway service: write .npmrc directly to fix npm prefix

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,15 @@ jobs:
                 ;;
               update)
                 echo "Updating moltbot..."
-                sudo su - ${{ env.MOLTBOT_USER }} -c "npm update -g moltbot" || true
+                # Ensure npm prefix is configured (fixes missing .npmrc from earlier installs)
+                if ! grep -q "prefix=" /home/${{ env.MOLTBOT_USER }}/.npmrc 2>/dev/null; then
+                  echo "prefix=/home/${{ env.MOLTBOT_USER }}/.npm-global" > /home/${{ env.MOLTBOT_USER }}/.npmrc
+                  chown ${{ env.MOLTBOT_USER }}:${{ env.MOLTBOT_USER }} /home/${{ env.MOLTBOT_USER }}/.npmrc
+                  echo "Fixed: wrote npm prefix to .npmrc"
+                fi
+                sudo su - ${{ env.MOLTBOT_USER }} -c "npm install -g moltbot@latest"
+                # Verify binary exists before restarting service
+                ls -la /home/${{ env.MOLTBOT_USER }}/.npm-global/bin/moltbot
                 sudo systemctl restart moltbot-gateway || echo "Service not yet configured"
                 ;;
               restart)


### PR DESCRIPTION
The `sudo -u moltbot npm config set prefix ...` command was writing to
the wrong .npmrc because sudo doesn't reset HOME by default. This meant
/home/moltbot/.npmrc never got the prefix setting, so `npm install -g`
placed the binary in the system global location instead of
/home/moltbot/.npm-global/bin/.

Changes:
- install.sh: Write .npmrc file directly instead of using `npm config set`
  through sudo, avoiding the HOME environment variable issue
- install.sh: Add post-install verification that the binary exists at
  the expected path, with diagnostic output on failure
- deploy.yml: Ensure .npmrc has prefix set before update (self-healing
  for servers installed with the broken script)
- deploy.yml: Use `npm install -g moltbot@latest` instead of
  `npm update -g moltbot` for more reliable updates
- deploy.yml: Verify binary exists before restarting service

https://claude.ai/code/session_01RyRV9Bq7fbNquQgMxwBAti