### PR TITLE
Fix npm binary: use moltbot@beta tag to get working bin field (#3787)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
                   chown ${{ env.MOLTBOT_USER }}:${{ env.MOLTBOT_USER }} /home/${{ env.MOLTBOT_USER }}/.npmrc
                   echo "Fixed: wrote npm prefix to .npmrc"
                 fi
-                sudo su - ${{ env.MOLTBOT_USER }} -c "npm install -g moltbot@latest"
+                sudo su - ${{ env.MOLTBOT_USER }} -c "npm install -g moltbot@beta"
                 # Verify binary exists before restarting service
                 ls -la /home/${{ env.MOLTBOT_USER }}/.npm-global/bin/moltbot
                 sudo systemctl restart moltbot-gateway || echo "Service not yet configured"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -163,7 +163,10 @@ install_moltbot() {
     log_info "Installing moltbot..."
 
     # Install moltbot as the moltbot user (-i loads login shell which sets HOME)
-    sudo -u "$MOLTBOT_USER" -i npm install -g moltbot@latest
+    # Use @beta tag: the @latest (v0.1.0) tag is a placeholder package
+    # missing the "bin" field, so npm creates no executable.
+    # See https://github.com/moltbot/moltbot/issues/3787
+    sudo -u "$MOLTBOT_USER" -i npm install -g moltbot@beta
 
     # Verify binary was installed to the correct location
     if [[ ! -x "${MOLTBOT_HOME}/.npm-global/bin/moltbot" ]]; then

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -51,7 +51,7 @@ update_moltbot() {
     # Update via npm
     sudo -u "$MOLTBOT_USER" -i bash -c '
         export PATH="${HOME}/.npm-global/bin:${PATH}"
-        npm update -g moltbot
+        npm install -g moltbot@beta
     '
 
     NEW_VERSION=$(get_current_version)


### PR DESCRIPTION
The moltbot@latest (v0.1.0) npm package is a placeholder missing the
"bin" field, so `npm install -g moltbot@latest` installs the package
but creates no executable. The @beta tag (v2026.1.27-beta.1) has the
correct bin configuration.

See https://github.com/moltbot/moltbot/issues/3787

https://claude.ai/code/session_01KuiWVJp5o4rLYxYMCqA5H6