### PR TITLE
Fix shellcheck SC2034: remove unused MOLTBOT_HOME variable

### DIFF
--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -13,7 +13,6 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 
 MOLTBOT_USER="${MOLTBOT_USER:-moltbot}"
-MOLTBOT_HOME="/home/${MOLTBOT_USER}"
 MOLTBOT_PORT="${MOLTBOT_PORT:-18789}"
 
 log_info() {


### PR DESCRIPTION
The variable was defined but never referenced in uninstall.sh.

https://claude.ai/code/session_01E18zuM971on4JgD2AihVah