### PR TITLE
Fix actionlint: replace raven-actions with direct binary download

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,10 +27,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install actionlint
+        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
       - name: Run actionlint
-        uses: raven-actions/actionlint@v2
-        with:
-          matcher: true
+        run: ./actionlint -color
 
   yamllint:
     name: YAML Lint


### PR DESCRIPTION
The raven-actions/actionlint@v2 composite action installs
@actions/tool-cache into the repo's node_modules, causing
ERR_PACKAGE_PATH_NOT_EXPORTED when actions/github-script resolves the
local copy instead of its own bundled version (raven-actions#26).

Switch to the official download script from rhysd/actionlint, which
downloads the binary directly and avoids the npm dependency chain
entirely.

https://claude.ai/code/session_013GEUboH9Mji8k1KLtnYtmd