### PR TITLE
Clean up stale npm directories before moltbot reinstall

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -202,6 +202,14 @@ NPMRC
 install_moltbot() {
     log_info "Installing moltbot..."
 
+    # Clean up stale npm temporary directories that cause ENOTEMPTY on reinstall.
+    # npm renames the existing package to a dotfile before replacing it; if a
+    # previous run was interrupted these leftovers block the next attempt.
+    local npm_modules="${MOLTBOT_HOME}/.npm-global/lib/node_modules"
+    if [[ -d "$npm_modules" ]]; then
+        find "$npm_modules" -maxdepth 1 -name '.moltbot-*' -type d -exec rm -rf {} + 2>/dev/null || true
+    fi
+
     # Install moltbot as the moltbot user (-i loads login shell which sets HOME)
     # Use @beta tag: the @latest (v0.1.0) tag is a placeholder package
     # missing the "bin" field, so npm creates no executable.


### PR DESCRIPTION
## Summary
Add cleanup logic to remove stale npm temporary directories before installing moltbot, preventing ENOTEMPTY errors during reinstallation.

## Changes
- Added pre-installation cleanup step in `install_moltbot()` function
- Removes leftover dotfile-prefixed directories (`.moltbot-*`) from npm's global node_modules
- Handles interrupted previous installation attempts that leave behind blocking artifacts

## Implementation Details
- Uses `find` command to locate stale directories at max depth 1 to avoid recursive traversal
- Safely handles missing directories with error suppression (`2>/dev/null || true`)
- Targets only moltbot-specific temporary directories to minimize side effects
- Executes cleanup before the actual moltbot npm installation to ensure a clean state

This resolves issues where npm's atomic rename operation (renaming existing package to dotfile before replacement) leaves artifacts if the previous installation was interrupted, blocking subsequent reinstall attempts.

https://claude.ai/code/session_01S75q6EN3zoJxzuiEePERRm