### PR TITLE
Pin GitHub Actions and refactor deployment scripts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Deploy to VPS
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USERNAME }}
@@ -107,7 +107,7 @@ jobs:
         run: sleep 10
 
       - name: Check service health
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USERNAME }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
         with:
           scandir: deploy
           severity: warning
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install actionlint
         run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Run yamllint
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c # v3
         with:
           file_or_dir: .
           config_data: |

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Shared library for Moltbot deployment scripts
+# Source this file at the top of each script:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "${SCRIPT_DIR}/lib.sh"
+#
+
+# Colors for output
+readonly LIB_RED='\033[0;31m'
+readonly LIB_GREEN='\033[0;32m'
+readonly LIB_YELLOW='\033[1;33m'
+readonly LIB_BLUE='\033[0;34m'
+readonly LIB_NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${LIB_BLUE}[INFO]${LIB_NC} $1"
+}
+
+log_success() {
+    echo -e "${LIB_GREEN}[SUCCESS]${LIB_NC} $1"
+}
+
+log_warn() {
+    echo -e "${LIB_YELLOW}[WARN]${LIB_NC} $1"
+}
+
+log_error() {
+    echo -e "${LIB_RED}[ERROR]${LIB_NC} $1"
+}
+
+# Verify the script is running as root
+require_root() {
+    if [[ $EUID -ne 0 ]]; then
+        log_error "This script must be run as root (use sudo)"
+        exit 1
+    fi
+}
+
+# Validate that a value is a valid TCP/UDP port number (1-65535)
+validate_port() {
+    local port="$1"
+    local name="${2:-port}"
+    if ! [[ "$port" =~ ^[0-9]+$ ]] || [[ "$port" -lt 1 ]] || [[ "$port" -gt 65535 ]]; then
+        log_error "Invalid ${name}: '${port}' (must be 1-65535)"
+        exit 1
+    fi
+}

--- a/deploy/moltbot-gateway.service
+++ b/deploy/moltbot-gateway.service
@@ -28,6 +28,12 @@ PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=read-only
 ReadWritePaths=/home/moltbot/.config/moltbot /home/moltbot/.local/share/moltbot /home/moltbot/.npm-global
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
 
 # Resource limits
 # NOTE: install.sh auto-tunes MemoryMax (75% of RAM, max 2G) and

--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -1,45 +1,19 @@
 #!/bin/bash
 #
-# Moltbot Uninstallation Script for Oracle Linux
+# Moltbot Uninstallation Script
 # Removes moltbot and its configuration
 #
 
 set -euo pipefail
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
 
 MOLTBOT_USER="${MOLTBOT_USER:-moltbot}"
 MOLTBOT_PORT="${MOLTBOT_PORT:-18789}"
 
-log_info() {
-    echo -e "${BLUE}[INFO]${NC} $1"
-}
-
-log_success() {
-    echo -e "${GREEN}[SUCCESS]${NC} $1"
-}
-
-log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
-}
-
-log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
-}
-
-check_root() {
-    if [[ $EUID -ne 0 ]]; then
-        log_error "This script must be run as root (use sudo)"
-        exit 1
-    fi
-}
-
 confirm_uninstall() {
-    echo -e "${YELLOW}WARNING: This will remove moltbot and all its data!${NC}"
+    echo -e "${LIB_YELLOW}WARNING: This will remove moltbot and all its data!${LIB_NC}"
     echo ""
     read -p "Are you sure you want to uninstall moltbot? (y/N): " -n 1 -r
     echo
@@ -82,12 +56,23 @@ remove_firewall_rule() {
 
     if systemctl is-active --quiet firewalld; then
         if firewall-cmd --list-ports | grep -q "${MOLTBOT_PORT}/tcp"; then
-            firewall-cmd --permanent --remove-port=${MOLTBOT_PORT}/tcp
+            firewall-cmd --permanent --remove-port="${MOLTBOT_PORT}/tcp"
             firewall-cmd --reload
             log_success "Firewall rule removed"
         else
             log_info "Firewall rule not found"
         fi
+    fi
+}
+
+remove_sudoers() {
+    log_info "Removing deploy sudoers rules..."
+
+    if [[ -f /etc/sudoers.d/moltbot-deploy ]]; then
+        rm /etc/sudoers.d/moltbot-deploy
+        log_success "Sudoers rules removed"
+    else
+        log_info "Sudoers file not found"
     fi
 }
 
@@ -112,12 +97,13 @@ main() {
     log_info "Moltbot Uninstallation Script"
     echo ""
 
-    check_root
+    require_root
     confirm_uninstall
 
     stop_service
     remove_service
     remove_firewall_rule
+    remove_sudoers
     remove_user
 
     echo ""


### PR DESCRIPTION
## Summary
This PR pins all GitHub Actions to specific commit SHAs for security and reproducibility, extracts common shell functions into a shared library, and improves the robustness of deployment scripts with better error handling and validation.

## Key Changes

### GitHub Actions Security
- Pin `actions/checkout` to SHA `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4) across all workflows
- Pin `appleboy/ssh-action` to SHA `029f5b4aeeeb58fdfe1410a5d17f967dacf36262` (v1.0.3) in deploy and health check jobs
- Pin `ludeeus/action-shellcheck` to SHA `00cae500b08a931fb5698e11e79bfbd38e612a38` (2.0.0)
- Pin `ibiqlik/action-yamllint` to SHA `2576378a8e339169678f9939646ee3ee325e845c` (v3)

### Script Refactoring
- Create new `deploy/lib.sh` shared library containing:
  - Color constants and logging functions (`log_info`, `log_success`, `log_warn`, `log_error`)
  - `require_root()` function for privilege validation
  - `validate_port()` function for port number validation
- Update all deployment scripts to source the shared library instead of duplicating code
- Rename `check_root()` to `require_root()` for consistency

### Enhanced Error Handling & Validation
- Add installation phase tracking with `INSTALL_PHASE` variable and `cleanup_on_failure()` trap in `install.sh`
- Add Node.js installation verification to ensure the `node` command is available
- Add port validation in `install.sh` and `update.sh`
- Improve sudoers configuration in `setup-server.sh` with:
  - Explicit `${DEPLOY_USER}` variable substitution instead of hardcoded "deploy"
  - Removal of overly permissive wildcards (e.g., `git *`, `chmod *`)
  - Addition of `visudo` syntax validation to prevent lockout
  - More restrictive `su` command specification

### Security Improvements
- Add additional systemd hardening directives to both `install.sh` and `moltbot-gateway.service`:
  - `ProtectKernelTunables=yes`
  - `ProtectKernelModules=yes`
  - `ProtectControlGroups=yes`
  - `RestrictNamespaces=yes`
  - `RestrictSUIDSGID=yes`
  - `LockPersonality=yes`
- Improve shell quoting for variables in firewall commands
- Add `remove_sudoers()` function to `uninstall.sh` for proper cleanup

### Code Quality
- Fix OS detection to use `source /etc/os-release` instead of deprecated `grep` parsing
- Add proper quoting around URLs in curl commands
- Use local variable declarations in `setup-server.sh`
- Improve port checking in `update.sh` to use word boundary regex (`\b`) for accuracy
- Add comments explaining security decisions in sudoers configuration

## Implementation Details
- All color constants in `lib.sh` are prefixed with `LIB_` to avoid namespace conflicts
- The shared library uses `readonly` for color constants to prevent accidental modification
- Installation phases are tracked to provide meaningful error messages on failure
- Sudoers validation uses `visudo -cf` to catch syntax errors before they cause lockout

https://claude.ai/code/session_01LtgUynfyVPsVN78oPg7dyx