### PR TITLE
Add temporary swap support for low-memory VPS installations

### DIFF
--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -30,11 +30,16 @@ update_moltbot() {
     CURRENT_VERSION=$(get_current_version)
     log_info "Current version: ${CURRENT_VERSION}"
 
+    # Ensure enough memory for npm install (OOM-killed on <1 GB VPS)
+    ensure_swap_for_install
+
     # Update via npm
     sudo -u "$MOLTBOT_USER" -i bash -c '
         export PATH="${HOME}/.npm-global/bin:${PATH}"
         npm install -g moltbot@beta
     '
+
+    remove_temp_swap
 
     NEW_VERSION=$(get_current_version)
     log_success "Updated to version: ${NEW_VERSION}"


### PR DESCRIPTION
## Summary
This PR adds automatic temporary swap file creation during npm installations to prevent out-of-memory (OOM) failures on small VPS instances with less than 1 GB of RAM.

## Problem
npm install can exceed available RAM on low-memory systems (<1 GB), causing the OOM killer to terminate the process and fail the installation. This is particularly problematic for moltbot installations on budget VPS instances.

## Solution
Implemented swap file management utilities that:
- Detect total available memory (RAM + existing swap)
- Create a temporary swap file if memory is below 2 GB threshold
- Activate the swap before npm operations
- Clean up the temporary swap file after installation completes

## Key Changes
- **deploy/lib.sh**: Added two new helper functions:
  - `ensure_swap_for_install()`: Creates and activates temporary swap if needed
  - `remove_temp_swap()`: Safely removes the temporary swap file
  - Configurable minimum memory threshold (2 GB) and minimum swap size (512 MB)

- **deploy/install.sh**: 
  - Call `ensure_swap_for_install()` before npm install
  - Call `remove_temp_swap()` after npm install completes
  - Added cleanup in `cleanup_on_failure()` to ensure swap is removed even on failure

- **deploy/update.sh**: 
  - Added same swap management around npm update operation

## Implementation Details
- Temporary swap file location: `/var/tmp/moltbot-install.swap`
- Memory detection uses `/proc/meminfo` for accuracy
- All swap operations are safe to call multiple times (idempotent)
- Comprehensive logging for visibility into swap creation/removal
- Graceful error handling with `|| true` to prevent failures if swap operations encounter issues

https://claude.ai/code/session_01Uuf43eG9ZnvNqVjN1M8fQh