### PR TITLE
Add GitHub Actions status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Moltbot Deployment
 
+[![Deploy to VPS](https://github.com/Joe-Heffer/moltbot/actions/workflows/deploy.yml/badge.svg)](https://github.com/Joe-Heffer/moltbot/actions/workflows/deploy.yml)
+[![Lint](https://github.com/Joe-Heffer/moltbot/actions/workflows/lint.yml/badge.svg)](https://github.com/Joe-Heffer/moltbot/actions/workflows/lint.yml)
+
 Deployment scripts and configuration for running [Moltbot](https://molt.bot) (formerly Clawdbot) on Linux VPS.
 
 ## What is Moltbot?


### PR DESCRIPTION
## Summary
Added GitHub Actions workflow status badges to the README to provide quick visibility into the CI/CD pipeline status.

## Changes
- Added badge for the "Deploy to VPS" workflow
- Added badge for the "Lint" workflow
- Badges link to their respective workflow pages on GitHub Actions

## Details
These badges serve as a quick reference for the project's build and deployment health, allowing contributors and users to see at a glance whether the latest commits pass linting checks and deployment workflows.

https://claude.ai/code/session_01CRJp1CHu11CXcw1ocYQmpT