### PR TITLE
Fix OOM kill during gateway runtime on low-memory VPS

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -63,24 +63,11 @@ detect_resources() {
         log_info "Applying low-memory optimizations automatically"
     fi
 
-    # Set MemoryMax to 75% of total RAM, capped at 2G
-    local ram_75pct=$(( TOTAL_RAM_MB * 75 / 100 ))
-    if [[ "$ram_75pct" -ge 2048 ]]; then
-        MEMORY_MAX="2G"
-    else
-        MEMORY_MAX="${ram_75pct}M"
-    fi
-
-    # Set Node.js max-old-space-size to 50% of total RAM, capped at 1536 MB
-    local heap_size=$(( TOTAL_RAM_MB * 50 / 100 ))
-    if [[ "$heap_size" -gt 1536 ]]; then
-        heap_size=1536
-    fi
-    # Floor at 128 MB to avoid startup failures
-    if [[ "$heap_size" -lt 128 ]]; then
-        heap_size=128
-    fi
-    NODE_HEAP_SIZE="$heap_size"
+    # Compute V8 heap and systemd MemoryMax from available RAM.
+    # See compute_memory_limits() in lib.sh for the formula.
+    compute_memory_limits
+    MEMORY_MAX="$LIB_MEMORY_MAX"
+    NODE_HEAP_SIZE="$LIB_NODE_HEAP_SIZE"
 
     log_info "Systemd MemoryMax: ${MEMORY_MAX}"
     log_info "Node.js heap limit: ${NODE_HEAP_SIZE} MB"

--- a/deploy/moltbot-gateway.service
+++ b/deploy/moltbot-gateway.service
@@ -36,9 +36,11 @@ RestrictSUIDSGID=yes
 LockPersonality=yes
 
 # Resource limits
-# NOTE: install.sh auto-tunes MemoryMax (75% of RAM, max 2G) and
-# NODE_OPTIONS --max-old-space-size (50% of RAM, max 1536M) based on
-# detected system memory. The values below are defaults for 4GB+ systems.
+# NOTE: install.sh and update.sh auto-tune MemoryMax and --max-old-space-size
+# based on detected system memory (see compute_memory_limits in lib.sh).
+# Formula: heap = 65% RAM (floor 256M, cap 1536M)
+#          MemoryMax = heap + 512M overhead (floor 512M, cap 2G, ≤ 90% RAM)
+# The values below are static defaults for 4 GB+ systems.
 LimitNOFILE=65535
 MemoryMax=2G
 


### PR DESCRIPTION
The V8 heap was exhausting at ~408 MB on systems with ≤1 GB RAM because
the old formula allocated only 50% of RAM to --max-old-space-size, and
MemoryMax was computed independently (75% RAM) leaving insufficient
headroom for Node.js native memory.

Changes:
- Add shared compute_memory_limits() to lib.sh with improved formula:
  heap = 65% RAM (floor 256M, cap 1536M)
  MemoryMax = heap + 512M overhead (floor 512M, cap 2G, ≤ 90% RAM)
- Refactor install.sh to use the shared function
- Add retune_service_resources() to update.sh so existing installs
  get corrected limits on the next update
- Update service template comment to document the formula

https://claude.ai/code/session_01E8PME71ZQyYqnXPhFCmBLo