### PR TITLE
Fix sudo password error in GitHub Actions deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,22 +57,22 @@ jobs:
             ACTION="${{ github.event.inputs.action || 'update' }}"
             echo "Action: $ACTION"
 
-            # Ensure deploy directory exists
-            sudo mkdir -p ${{ env.DEPLOY_PATH }}
+            # Deploy directory is owned by the deploy user (created by setup-server.sh)
             cd ${{ env.DEPLOY_PATH }}
 
             # Clone or update the repository
+            # No sudo — deploy user owns the directory
             if [ -d ".git" ]; then
               echo "Updating existing repository..."
-              sudo git fetch origin main
-              sudo git reset --hard origin/main
+              git fetch origin main
+              git reset --hard origin/main
             else
               echo "Cloning repository..."
-              sudo git clone https://github.com/${{ github.repository }}.git .
+              git clone https://github.com/${{ github.repository }}.git .
             fi
 
             # Make scripts executable
-            sudo chmod +x deploy/*.sh
+            chmod +x deploy/*.sh
 
             # Execute based on action
             case "$ACTION" in
@@ -82,16 +82,7 @@ jobs:
                 ;;
               update)
                 echo "Updating moltbot..."
-                # Ensure npm prefix is configured (fixes missing .npmrc from earlier installs)
-                if ! sudo grep -q "prefix=" /home/${{ env.MOLTBOT_USER }}/.npmrc 2>/dev/null; then
-                  echo "prefix=/home/${{ env.MOLTBOT_USER }}/.npm-global" | sudo tee /home/${{ env.MOLTBOT_USER }}/.npmrc > /dev/null
-                  sudo chown ${{ env.MOLTBOT_USER }}:${{ env.MOLTBOT_USER }} /home/${{ env.MOLTBOT_USER }}/.npmrc
-                  echo "Fixed: wrote npm prefix to .npmrc"
-                fi
-                sudo su - ${{ env.MOLTBOT_USER }} -c "npm install -g moltbot@beta"
-                # Verify binary exists before restarting service
-                ls -la /home/${{ env.MOLTBOT_USER }}/.npm-global/bin/moltbot
-                sudo systemctl restart moltbot-gateway || echo "Service not yet configured"
+                sudo ./deploy/update.sh
                 ;;
               restart)
                 echo "Restarting service..."

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -24,11 +24,23 @@ get_current_version() {
     sudo -u "$MOLTBOT_USER" -i moltbot --version 2>/dev/null || echo "unknown"
 }
 
+ensure_npm_prefix() {
+    local npmrc_path="/home/${MOLTBOT_USER}/.npmrc"
+    if ! grep -q "prefix=" "$npmrc_path" 2>/dev/null; then
+        echo "prefix=/home/${MOLTBOT_USER}/.npm-global" >> "$npmrc_path"
+        chown "${MOLTBOT_USER}:${MOLTBOT_USER}" "$npmrc_path"
+        log_info "Fixed: wrote npm prefix to .npmrc"
+    fi
+}
+
 update_moltbot() {
     log_info "Updating moltbot..."
 
     CURRENT_VERSION=$(get_current_version)
     log_info "Current version: ${CURRENT_VERSION}"
+
+    # Ensure npm prefix is configured (fixes missing .npmrc from earlier installs)
+    ensure_npm_prefix
 
     # Ensure enough memory for npm install (OOM-killed on <1 GB VPS)
     ensure_swap_for_install


### PR DESCRIPTION
The deploy workflow used sudo for commands (grep, tee, chown, git, mkdir,
chmod) that aren't in the sudoers allowlist created by setup-server.sh,
causing "sudo: a password is required" during the update action.

- Remove sudo from git/file operations in the deploy directory (owned by
  the deploy user, created by setup-server.sh)
- Replace inline update logic with `sudo ./deploy/update.sh` which is
  already in the sudoers allowlist and runs as root
- Move the .npmrc prefix fix into update.sh where it runs with proper
  privileges

https://claude.ai/code/session_01DCP8bTkLeUsP2jjHT3pQys