### PR TITLE
Fix export error during deployment update

### DIFF
--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -45,11 +45,8 @@ update_moltbot() {
     # Ensure enough memory for npm install (OOM-killed on <1 GB VPS)
     ensure_swap_for_install
 
-    # Update via npm
-    sudo -u "$MOLTBOT_USER" -i bash -c '
-        export PATH="${HOME}/.npm-global/bin:${PATH}"
-        npm install -g moltbot@beta
-    '
+    # Update via npm (-i sources .profile which sets PATH to include .npm-global/bin)
+    sudo -u "$MOLTBOT_USER" -i npm install -g moltbot@beta
 
     remove_temp_swap
 


### PR DESCRIPTION
sudo -i concatenates all arguments into a single escaped string before
passing them to the login shell.  The multi-line bash -c wrapper caused
the newline-separated export and npm commands to be flattened into one
line, making bash interpret "npm install -g moltbot@beta" as additional
arguments to export.

Replace with the same direct invocation used by install.sh — sudo -i
already sources .profile which sets PATH to include .npm-global/bin.

https://claude.ai/code/session_013YCnwpeDKZYVMafV82FSLq