### PR TITLE
Raise minimum RAM requirement from 1 GB to 2 GB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,4 +55,4 @@ There is no build step or test suite — this is a scripts-and-docs repository.
 - **System user**: `moltbot` (non-root, created by installer)
 - **Service**: `moltbot-gateway` systemd unit on port 18789
 - **Security**: `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=read-only`, dedicated user
-- **Low-memory**: Auto-tunes `MemoryMax` and `--max-old-space-size`; temporary swap for installs on <2 GB RAM
+- **Low-memory**: Auto-tunes `MemoryMax` and `--max-old-space-size`; temporary swap for installs on <4 GB RAM; minimum 2 GB RAM enforced by installer

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Moltbot is a personal AI assistant that runs on your own hardware. It connects t
 
 - Ubuntu Linux 24.04 LTS
 - Root/sudo access
-- At least 1 GB RAM (2 GB recommended, 4 GB ideal)
+- At least 2 GB RAM (4 GB recommended); see the [official system requirements](https://docs.molt.bot/help/faq)
 - An API key from [Anthropic](https://console.anthropic.com/) or [OpenAI](https://platform.openai.com/)
 
 > **Low-memory VPS**: The installer automatically detects available RAM and
 > tunes `MemoryMax` and Node.js heap size accordingly. Systems with less than
-> 2 GB RAM will work but should add swap space (see [Low-Memory VPS](#low-memory-vps) below).
+> 4 GB RAM should add swap space (see [Low-Memory VPS](#low-memory-vps) below).
 
 ## Quick Start
 
@@ -212,14 +212,16 @@ For secure remote access, consider using [Tailscale Serve/Funnel](https://docs.m
 
 ## Low-Memory VPS
 
-If your VPS has 1 GB RAM (e.g. an entry-level VPS with 1 vCPU / 1 GB / 10 GB SSD), the installer will automatically apply low-memory optimizations:
+The minimum RAM for running Moltbot is 2 GB (see [official system requirements](https://docs.molt.bot/help/faq)). Systems with 1 GB RAM do not have enough memory for the Node.js runtime, V8 heap, and channel connections combined — the OOM killer will terminate the gateway under normal operation.
 
-| Setting | 1 GB RAM | 2 GB RAM | 4 GB+ RAM |
-|---------|----------|----------|-----------|
-| `MemoryMax` | 768M | 1536M | 2G |
-| `--max-old-space-size` | 512 MB | 1024 MB | 1536 MB |
+The installer automatically tunes resource limits based on detected RAM:
 
-### Adding swap space (recommended for <= 1 GB RAM)
+| Setting | 2 GB RAM | 4 GB+ RAM |
+|---------|----------|-----------|
+| `MemoryMax` | 1536M | 2G |
+| `--max-old-space-size` | 1024 MB | 1536 MB |
+
+### Adding swap space (recommended for 2 GB RAM)
 
 Creating a swap file prevents the OOM killer from terminating moltbot during memory spikes:
 
@@ -240,7 +242,7 @@ sudo sysctl -p
 
 ### Reducing channel overhead
 
-Each messaging channel (WhatsApp, Telegram, Discord, Slack) maintains a persistent connection that consumes memory. On a 1 GB VPS, enable only the channels you need in your `.env` file.
+Each messaging channel (WhatsApp, Telegram, Discord, Slack) maintains a persistent connection that consumes memory. On a 2 GB VPS, enable only the channels you need in your `.env` file.
 
 ## Troubleshooting
 

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -56,10 +56,13 @@ detect_resources() {
     TOTAL_RAM_MB=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024 }' /proc/meminfo)
     log_info "Total RAM: ${TOTAL_RAM_MB} MB"
 
-    if [[ "$TOTAL_RAM_MB" -lt 1024 ]]; then
-        log_warn "System has less than 1 GB RAM — moltbot may be unstable"
-    elif [[ "$TOTAL_RAM_MB" -lt 2048 ]]; then
-        log_warn "System has less than 2 GB RAM (recommended minimum)"
+    if [[ "$TOTAL_RAM_MB" -lt 2048 ]]; then
+        log_error "System has less than 2 GB RAM (minimum requirement)"
+        log_error "Moltbot requires at least 2 GB RAM to run reliably."
+        log_error "See: https://docs.molt.bot/help/faq"
+        exit 1
+    elif [[ "$TOTAL_RAM_MB" -lt 4096 ]]; then
+        log_warn "System has less than 4 GB RAM (recommended)"
         log_info "Applying low-memory optimizations automatically"
     fi
 
@@ -216,7 +219,7 @@ install_moltbot() {
         find "$npm_modules" -maxdepth 1 -name '.moltbot-*' -type d -exec rm -rf {} + 2>/dev/null || true
     fi
 
-    # Ensure enough memory for npm install (OOM-killed on <1 GB VPS)
+    # Ensure enough memory for npm install (OOM-killed on low-memory VPS)
     ensure_swap_for_install
 
     # Install moltbot as the moltbot user (-i loads login shell which sets HOME)

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -48,7 +48,7 @@ validate_port() {
 }
 
 # Temporary swap support for low-memory systems
-# npm install can exceed available RAM on small VPS instances (<1 GB),
+# npm install can exceed available RAM on small VPS instances (<4 GB),
 # causing the OOM killer to SIGKILL the process.  These helpers create
 # a temporary swap file before the install and clean it up afterwards.
 

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -42,7 +42,7 @@ update_moltbot() {
     # Ensure npm prefix is configured (fixes missing .npmrc from earlier installs)
     ensure_npm_prefix
 
-    # Ensure enough memory for npm install (OOM-killed on <1 GB VPS)
+    # Ensure enough memory for npm install (OOM-killed on low-memory VPS)
     ensure_swap_for_install
 
     # Update via npm (-i sources .profile which sets PATH to include .npm-global/bin)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -8,13 +8,12 @@ This repository provides production-ready deployment scripts for running Moltbot
 - Ubuntu / Debian
 - RHEL / Oracle Linux
 
-**Hardware requirements:**
+**Hardware requirements** (see [official system requirements](https://docs.molt.bot/help/faq)):
 
 | RAM | MemoryMax | Node.js Heap | Notes |
 |-----|-----------|-------------|-------|
-| 1 GB | 768 MB | 512 MB | Minimum viable; consider adding swap |
-| 2 GB | 1.5 GB | 1 GB | Recommended minimum |
-| 4+ GB | 2 GB | 1.5 GB | Comfortable headroom |
+| 2 GB | 1.5 GB | 1 GB | Minimum; consider adding swap |
+| 4+ GB | 2 GB | 1.5 GB | Recommended; comfortable headroom |
 
 The installer auto-tunes resource limits based on detected RAM.
 

--- a/docs/use-cases-and-deployment.md
+++ b/docs/use-cases-and-deployment.md
@@ -137,13 +137,12 @@ operation.
 - Ubuntu / Debian
 - RHEL / Oracle Linux
 
-**Hardware requirements:**
+**Hardware requirements** (see [official system requirements](https://docs.molt.bot/help/faq)):
 
 | RAM | MemoryMax | Node.js Heap | Notes |
 |-----|-----------|-------------|-------|
-| 1 GB | 768 MB | 512 MB | Minimum viable; consider adding swap |
-| 2 GB | 1.5 GB | 1 GB | Recommended minimum |
-| 4+ GB | 2 GB | 1.5 GB | Comfortable headroom |
+| 2 GB | 1.5 GB | 1 GB | Minimum; consider adding swap |
+| 4+ GB | 2 GB | 1.5 GB | Recommended; comfortable headroom |
 
 The installer auto-tunes resource limits based on detected RAM.
 


### PR DESCRIPTION
1 GB RAM is insufficient for the Node.js runtime, V8 heap, and
channel connections combined — the OOM killer terminates the gateway
under normal operation. Update all documentation and hardware
requirement tables to reflect 2 GB as the minimum, with 4 GB
recommended. The installer now refuses to proceed on <2 GB systems
with a pointer to the official system requirements at
docs.molt.bot/help/faq.

https://claude.ai/code/session_01Gp5spwb3JvAiQAdaMQ8PA6