### PR TITLE
Remove unsupported script_stop input from ssh-action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,6 @@ jobs:
           username: ${{ secrets.VPS_USERNAME }}
           key: ${{ secrets.VPS_SSH_KEY }}
           port: ${{ secrets.VPS_PORT || 22 }}
-          script_stop: false
           script: |
             set -e
 
@@ -113,7 +112,6 @@ jobs:
           username: ${{ secrets.VPS_USERNAME }}
           key: ${{ secrets.VPS_SSH_KEY }}
           port: ${{ secrets.VPS_PORT || 22 }}
-          script_stop: false
           script: |
             set -e
             echo "=== Health Check ==="


### PR DESCRIPTION
The appleboy/ssh-action v1.2.5 no longer accepts script_stop as an
input parameter, causing the deploy workflow to fail. The scripts
already use set -e for error handling, so the parameter is redundant.

https://claude.ai/code/session_017CL5iYPo5qk3KHg2woR6y5