### PR TITLE
Fix ShellCheck lint and show diagnostics on deploy failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,9 @@ jobs:
             # Make scripts executable
             chmod +x deploy/*.sh
 
+            # Disable errexit so diagnostics always run, even on failure
+            set +e
+
             # Execute based on action
             case "$ACTION" in
               install)
@@ -88,13 +91,27 @@ jobs:
                 sudo systemctl restart moltbot-gateway
                 ;;
             esac
+            DEPLOY_EXIT=$?
 
-            # Show status
+            set -e
+
+            # Always show status (even on failure, for diagnostics)
             echo ""
-            echo "=== Deployment Complete ==="
-            sudo systemctl status moltbot-gateway || true
+            echo "=== Deployment Status ==="
+            sudo systemctl status moltbot-gateway --no-pager || true
             echo ""
             sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot --version" || echo "Moltbot not yet installed"
+
+            # On failure, dump recent logs to help debug
+            if [ "$DEPLOY_EXIT" -ne 0 ]; then
+              echo ""
+              echo "=== Deploy failed (exit $DEPLOY_EXIT) — recent service logs ==="
+              sudo journalctl -u moltbot-gateway -n 50 --no-pager || true
+              exit "$DEPLOY_EXIT"
+            fi
+
+            echo ""
+            echo "=== Deployment Complete ==="
 
   health-check:
     name: Health Check

--- a/deploy/lib.sh
+++ b/deploy/lib.sh
@@ -109,9 +109,13 @@ remove_temp_swap() {
 #   1. V8 gets enough room to handle spikes without heap OOM.
 #   2. systemd MemoryMax leaves headroom for native overhead so the
 #      cgroup OOM-killer doesn't fire before V8 can GC.
+# Set by compute_memory_limits(), read by sourcing scripts (install.sh, update.sh)
+# shellcheck disable=SC2034
 LIB_NODE_HEAP_SIZE=""
+# shellcheck disable=SC2034
 LIB_MEMORY_MAX=""
 
+# shellcheck disable=SC2034
 compute_memory_limits() {
     local total_ram_mb
     total_ram_mb=$(awk '/^MemTotal:/ { printf "%d", $2 / 1024 }' /proc/meminfo)


### PR DESCRIPTION
- Suppress SC2034 warnings for LIB_NODE_HEAP_SIZE and LIB_MEMORY_MAX
  in lib.sh (cross-file globals read by sourcing scripts)
- Disable errexit before deploy command so diagnostic output always
  runs, even when the deploy script exits non-zero
- Dump systemctl status, moltbot version, and journalctl logs on
  failure to make the root cause visible in GitHub Actions logs

https://claude.ai/code/session_01HNfZPXCtJcabNL6EBsZyHC