### PR TITLE
Add scheduled security audit workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,58 @@
+# Security audit workflow
+# Runs moltbot security checks on a regular schedule
+# Reference: https://docs.molt.bot/gateway/security
+
+name: Security Audit
+
+on:
+  schedule:
+    # Run weekly on Monday at 06:00 UTC
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: security-audit
+  cancel-in-progress: false
+
+env:
+  MOLTBOT_USER: moltbot
+
+permissions:
+  contents: read
+
+jobs:
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Run deep security audit
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USERNAME }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: ${{ secrets.VPS_PORT || 22 }}
+          script: |
+            set -e
+
+            echo "=== Moltbot Security Audit ==="
+
+            # Run deep audit first to surface all findings
+            echo ""
+            echo "--- Deep Audit ---"
+            sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot security audit --deep"
+
+            # Apply safe automated fixes
+            echo ""
+            echo "--- Applying Fixes ---"
+            sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot security audit --fix"
+
+            # Re-run deep audit to confirm clean state
+            echo ""
+            echo "--- Verification Audit ---"
+            sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot security audit --deep"
+
+            echo ""
+            echo "=== Security Audit Complete ==="


### PR DESCRIPTION
Run `moltbot security audit --deep` and `--fix` weekly on the
production VPS, then re-run the deep audit to verify a clean state.
Supports manual dispatch for on-demand runs.

Ref: https://docs.molt.bot/gateway/security

https://claude.ai/code/session_01SLPd1gKqY4aug5NnSABsVD