### PR TITLE
Add .clawdbot directory support to moltbot installation

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -163,6 +163,7 @@ create_moltbot_user() {
     mkdir -p "$MOLTBOT_CONFIG_DIR"
     mkdir -p "$MOLTBOT_DATA_DIR"
     mkdir -p "${MOLTBOT_HOME}/.npm-global"
+    mkdir -p "${MOLTBOT_HOME}/.clawdbot"
 
     # Set npm global prefix for the moltbot user
     # Write .npmrc directly to avoid sudo HOME environment issues
@@ -266,7 +267,7 @@ Environment=NODE_OPTIONS=--max-old-space-size=${NODE_HEAP_SIZE}
 Environment=PATH=${MOLTBOT_HOME}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=${MOLTBOT_HOME}
 EnvironmentFile=-${MOLTBOT_CONFIG_DIR}/.env
-ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x ${MOLTBOT_HOME}/.npm-global/bin/moltbot || { echo "FATAL: ${MOLTBOT_HOME}/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f ${MOLTBOT_CONFIG_DIR}/.env || echo "WARN: ${MOLTBOT_CONFIG_DIR}/.env not found, running without env file"'
+ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x ${MOLTBOT_HOME}/.npm-global/bin/moltbot || { echo "FATAL: ${MOLTBOT_HOME}/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f ${MOLTBOT_CONFIG_DIR}/.env || echo "WARN: ${MOLTBOT_CONFIG_DIR}/.env not found, running without env file" && mkdir -p ${MOLTBOT_HOME}/.clawdbot'
 ExecStart=${MOLTBOT_HOME}/.npm-global/bin/moltbot gateway --port ${MOLTBOT_PORT}
 Restart=always
 RestartSec=10
@@ -279,7 +280,7 @@ NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=${MOLTBOT_CONFIG_DIR} ${MOLTBOT_DATA_DIR} ${MOLTBOT_HOME}/.npm-global
+ReadWritePaths=${MOLTBOT_CONFIG_DIR} ${MOLTBOT_DATA_DIR} ${MOLTBOT_HOME}/.npm-global ${MOLTBOT_HOME}/.clawdbot
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes

--- a/deploy/moltbot-gateway.service
+++ b/deploy/moltbot-gateway.service
@@ -14,7 +14,7 @@ Environment=NODE_OPTIONS=--max-old-space-size=1536
 Environment=PATH=/home/moltbot/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=/home/moltbot
 EnvironmentFile=-/home/moltbot/.config/moltbot/.env
-ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x /home/moltbot/.npm-global/bin/moltbot || { echo "FATAL: /home/moltbot/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f /home/moltbot/.config/moltbot/.env || echo "WARN: /home/moltbot/.config/moltbot/.env not found, running without env file"'
+ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x /home/moltbot/.npm-global/bin/moltbot || { echo "FATAL: /home/moltbot/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f /home/moltbot/.config/moltbot/.env || echo "WARN: /home/moltbot/.config/moltbot/.env not found, running without env file" && mkdir -p /home/moltbot/.clawdbot'
 ExecStart=/home/moltbot/.npm-global/bin/moltbot gateway --port 18789
 Restart=always
 RestartSec=10
@@ -27,7 +27,7 @@ NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/home/moltbot/.config/moltbot /home/moltbot/.local/share/moltbot /home/moltbot/.npm-global
+ReadWritePaths=/home/moltbot/.config/moltbot /home/moltbot/.local/share/moltbot /home/moltbot/.npm-global /home/moltbot/.clawdbot
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes


### PR DESCRIPTION
## Summary
This PR adds support for a `.clawdbot` directory in the moltbot home directory, ensuring it is created during installation and accessible to the moltbot-gateway service.

## Changes
- **Installation script**: Create `.clawdbot` directory during user setup alongside other required directories
- **Pre-start checks**: Add directory creation to the systemd service pre-start hook to ensure the directory exists at runtime
- **Service permissions**: Grant read-write access to `.clawdbot` directory in the systemd security configuration
- **Template and concrete service files**: Apply changes to both the parameterized install script template and the concrete moltbot-gateway.service file

## Implementation Details
The `.clawdbot` directory is created in two places:
1. During initial setup in `create_moltbot_user()` function
2. As a pre-start check in the systemd service to handle edge cases where the directory may be removed

The directory is added to `ReadWritePaths` in the systemd service configuration to allow the moltbot-gateway process to read and write to this location while maintaining strict security constraints (`ProtectHome=read-only`).

https://claude.ai/code/session_015Th28jiQe4SL3BoCdsunah