### PR TITLE
Add --repair flag to doctor command and run it after service restart

### DIFF
--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -161,8 +161,8 @@ show_status() {
 }
 
 run_doctor() {
-    log_info "Running moltbot doctor..."
-    sudo -u "$MOLTBOT_USER" -i moltbot doctor 2>/dev/null || true
+    log_info "Running moltbot doctor --repair..."
+    sudo -u "$MOLTBOT_USER" -i moltbot doctor --repair 2>/dev/null || true
 }
 
 main() {
@@ -177,6 +177,7 @@ main() {
     restart_service
 
     if wait_for_healthy; then
+        run_doctor
         show_status
         log_success "Update completed successfully"
     else


### PR DESCRIPTION
## Summary
Updated the deployment script to run `moltbot doctor` with the `--repair` flag and moved its execution to occur after the service restart completes successfully.

## Key Changes
- Modified `run_doctor()` function to invoke `moltbot doctor --repair` instead of `moltbot doctor`
- Relocated `run_doctor()` call to execute after `wait_for_healthy()` succeeds, ensuring the service is running before attempting repairs
- Updated log message to reflect the new `--repair` flag usage

## Implementation Details
- The `--repair` flag enables automatic remediation of detected issues during the health check
- Running doctor after confirming service health ensures a stable state before attempting repairs
- The command continues to suppress output and ignore failures with `2>/dev/null || true` to prevent deployment interruption

https://claude.ai/code/session_0132LEuz1RHwgX3o1C11hNp1