### PR TITLE
Harden .clawdbot state directory permissions and improve security audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,10 +49,31 @@ jobs:
             echo "--- Applying Fixes ---"
             sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot security audit --fix"
 
+            # The --fix flag skips chmod on symlinks for safety.
+            # Resolve the symlink (if any) and harden the state dir ourselves.
+            echo ""
+            echo "--- Hardening State Directory ---"
+            STATE_DIR="/home/${{ env.MOLTBOT_USER }}/.clawdbot"
+            if [ -L "$STATE_DIR" ]; then
+              REAL_DIR=$(readlink -f "$STATE_DIR")
+              echo "State dir is symlink -> ${REAL_DIR}; fixing permissions on resolved path"
+              sudo chmod 700 "$REAL_DIR"
+            elif [ -d "$STATE_DIR" ]; then
+              sudo chmod 700 "$STATE_DIR"
+            fi
+
             # Re-run deep audit to confirm clean state
             echo ""
             echo "--- Verification Audit ---"
-            sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot security audit --deep"
+            AUDIT_OUTPUT=$(sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot security audit --deep" 2>&1)
+            echo "$AUDIT_OUTPUT"
+
+            # Fail the workflow if any CRITICAL findings remain
+            if echo "$AUDIT_OUTPUT" | grep -q "CRITICAL"; then
+              echo ""
+              echo "FAIL: Critical security findings remain after remediation"
+              exit 1
+            fi
 
             echo ""
             echo "=== Security Audit Complete ==="

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -164,6 +164,7 @@ create_moltbot_user() {
     mkdir -p "$MOLTBOT_DATA_DIR"
     mkdir -p "${MOLTBOT_HOME}/.npm-global"
     mkdir -p "${MOLTBOT_HOME}/.clawdbot"
+    chmod 700 "${MOLTBOT_HOME}/.clawdbot"
 
     # Set npm global prefix for the moltbot user
     # Write .npmrc directly to avoid sudo HOME environment issues
@@ -267,7 +268,7 @@ Environment=NODE_OPTIONS=--max-old-space-size=${NODE_HEAP_SIZE}
 Environment=PATH=${MOLTBOT_HOME}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=${MOLTBOT_HOME}
 EnvironmentFile=-${MOLTBOT_CONFIG_DIR}/.env
-ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x ${MOLTBOT_HOME}/.npm-global/bin/moltbot || { echo "FATAL: ${MOLTBOT_HOME}/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f ${MOLTBOT_CONFIG_DIR}/.env || echo "WARN: ${MOLTBOT_CONFIG_DIR}/.env not found, running without env file" && mkdir -p ${MOLTBOT_HOME}/.clawdbot'
+ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x ${MOLTBOT_HOME}/.npm-global/bin/moltbot || { echo "FATAL: ${MOLTBOT_HOME}/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f ${MOLTBOT_CONFIG_DIR}/.env || echo "WARN: ${MOLTBOT_CONFIG_DIR}/.env not found, running without env file" && mkdir -p ${MOLTBOT_HOME}/.clawdbot && chmod 700 ${MOLTBOT_HOME}/.clawdbot'
 ExecStart=${MOLTBOT_HOME}/.npm-global/bin/moltbot gateway --port ${MOLTBOT_PORT}
 Restart=always
 RestartSec=10

--- a/deploy/moltbot-gateway.service
+++ b/deploy/moltbot-gateway.service
@@ -14,7 +14,7 @@ Environment=NODE_OPTIONS=--max-old-space-size=1536
 Environment=PATH=/home/moltbot/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=/home/moltbot
 EnvironmentFile=-/home/moltbot/.config/moltbot/.env
-ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x /home/moltbot/.npm-global/bin/moltbot || { echo "FATAL: /home/moltbot/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f /home/moltbot/.config/moltbot/.env || echo "WARN: /home/moltbot/.config/moltbot/.env not found, running without env file" && mkdir -p /home/moltbot/.clawdbot'
+ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x /home/moltbot/.npm-global/bin/moltbot || { echo "FATAL: /home/moltbot/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f /home/moltbot/.config/moltbot/.env || echo "WARN: /home/moltbot/.config/moltbot/.env not found, running without env file" && mkdir -p /home/moltbot/.clawdbot && chmod 700 /home/moltbot/.clawdbot'
 ExecStart=/home/moltbot/.npm-global/bin/moltbot gateway --port 18789
 Restart=always
 RestartSec=10


### PR DESCRIPTION
## Summary
This PR improves security hardening by ensuring the `.clawdbot` state directory has restrictive permissions (700) across installation, startup, and remediation flows. It also enhances the security audit workflow to detect and fail on critical findings.

## Key Changes

- **State directory permission hardening**: Added `chmod 700` to the `.clawdbot` directory in three locations:
  - During initial user setup in `deploy/install.sh`
  - In systemd service pre-start checks in both `deploy/install.sh` template and `deploy/moltbot-gateway.service`

- **Security audit workflow improvements**:
  - Added explicit symlink resolution and permission hardening for the state directory after running `moltbot security audit --fix`
  - Captures audit output and checks for CRITICAL findings
  - Fails the workflow if any CRITICAL security issues remain after remediation
  - Provides clear logging of the remediation and verification steps

## Implementation Details

The changes address a gap where the `--fix` flag in the security audit tool skips chmod operations on symlinks for safety. The workflow now:
1. Runs the security audit with fixes
2. Manually resolves any symlinks and applies `chmod 700` to the actual directory
3. Re-runs the audit and validates that no CRITICAL findings remain
4. Fails fast if critical issues are detected, preventing deployment of insecure state

This ensures consistent permission enforcement whether the state directory is a regular directory or a symlink, and provides confidence that security issues are actually resolved before the workflow completes.

https://claude.ai/code/session_01EeS7bnKHJMdgqfjmesERNr