### PR TITLE
Fix moltbot binary path resolution in security audit workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,15 +39,24 @@ jobs:
 
             echo "=== Moltbot Security Audit ==="
 
+            # Use absolute path — the moltbot user's login shell may not
+            # have ~/.npm-global/bin in PATH (useradd -r skips /etc/skel,
+            # and non-interactive login shells may not source .profile).
+            MOLTBOT_BIN="/home/${{ env.MOLTBOT_USER }}/.npm-global/bin/moltbot"
+            if [ ! -x "$MOLTBOT_BIN" ]; then
+              echo "FAIL: moltbot binary not found at $MOLTBOT_BIN"
+              exit 1
+            fi
+
             # Run deep audit first to surface all findings
             echo ""
             echo "--- Deep Audit ---"
-            sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot security audit --deep"
+            sudo -u ${{ env.MOLTBOT_USER }} "$MOLTBOT_BIN" security audit --deep
 
             # Apply safe automated fixes
             echo ""
             echo "--- Applying Fixes ---"
-            sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot security audit --fix"
+            sudo -u ${{ env.MOLTBOT_USER }} "$MOLTBOT_BIN" security audit --fix
 
             # The --fix flag skips chmod on symlinks for safety.
             # Resolve the symlink (if any) and harden the state dir ourselves.
@@ -65,7 +74,7 @@ jobs:
             # Re-run deep audit to confirm clean state
             echo ""
             echo "--- Verification Audit ---"
-            AUDIT_OUTPUT=$(sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot security audit --deep" 2>&1)
+            AUDIT_OUTPUT=$(sudo -u ${{ env.MOLTBOT_USER }} "$MOLTBOT_BIN" security audit --deep 2>&1)
             echo "$AUDIT_OUTPUT"
 
             # Fail the workflow if any CRITICAL findings remain


### PR DESCRIPTION
## Summary
Updated the security audit workflow to use absolute paths and `sudo -u` instead of `sudo su -` for more reliable moltbot binary execution. This addresses issues where the moltbot user's login shell may not have the npm global bin directory in its PATH.

## Key Changes
- Added explicit absolute path resolution for the moltbot binary (`/home/$MOLTBOT_USER/.npm-global/bin/moltbot`)
- Added validation to ensure the binary exists and is executable before attempting to run audits
- Replaced `sudo su - ${{ env.MOLTBOT_USER }} -c "moltbot ..."` with `sudo -u ${{ env.MOLTBOT_USER }} "$MOLTBOT_BIN" ...` for all three audit invocations (deep audit, fix, and verification)

## Implementation Details
The change accounts for the fact that non-interactive login shells spawned by `useradd -r` skip `/etc/skel` and may not source `.profile`, which would normally add `~/.npm-global/bin` to PATH. By using an absolute path and `sudo -u` (which doesn't spawn a login shell), we ensure the binary is found reliably regardless of shell configuration.

The binary existence check provides early failure with a clear error message if the moltbot installation is incomplete or misconfigured.

https://claude.ai/code/session_012mp1snvZDHLRrLPcRdUsJ9