### PR TITLE
Clarify Telegram chat ID requirements in docs and config

### DIFF
--- a/deploy/moltbot.env.template
+++ b/deploy/moltbot.env.template
@@ -53,7 +53,8 @@ MOLTBOT_HOST=0.0.0.0
 # "pairing" requires approval for new contacts
 # DM_POLICY=pairing
 
-# Allowlist for DMs (comma-separated phone numbers or usernames)
+# Allowlist for DMs (comma-separated identifiers)
+# Use phone numbers for WhatsApp, numeric chat IDs for Telegram, usernames for others.
 # Use "*" to allow all (NOT recommended for security)
 # DM_ALLOWLIST=
 

--- a/docs/TELEGRAM_SETUP.md
+++ b/docs/TELEGRAM_SETUP.md
@@ -142,6 +142,23 @@ Message your bot on Telegram again — it should now respond normally.
 > Telegram username to interact with it. Switch back to `pairing` once a
 > fixed version of Moltbot is released.
 
+## Telegram Uses Chat IDs, Not Phone Numbers
+
+Telegram bots identify users by a numeric **chat ID** (e.g., `123456789`), not
+by phone number. If you pass a phone number like `+447901234567` as a Telegram
+target, you will get an error:
+
+```
+Unknown target "+44790..." for Telegram. Hint: <chatId>
+```
+
+To find your chat ID, send any message to your bot — the pairing prompt
+includes your Telegram user id. Use that numeric id wherever a Telegram target
+is required (e.g., in `DM_ALLOWLIST` or when calling the `message` tool).
+
+See the [Troubleshooting Guide](./TROUBLESHOOTING.md#unknown-target-phone-number-error-on-telegram)
+for details.
+
 ## Security Notes
 
 - The `.env` file lives at `/home/moltbot/.config/moltbot/.env` with `600` permissions, so only the `moltbot` system user can read it.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -87,6 +87,32 @@ sudo systemctl restart moltbot-gateway
 
 The bot will now respond to all Telegram messages without requiring approval. Switch back to `DM_POLICY=pairing` once a fixed version is released. See the [Telegram Setup Guide](./TELEGRAM_SETUP.md#workaround-set-dm_policyopen) for details.
 
+### "Unknown target" phone number error on Telegram
+
+**Symptom:** Moltbot returns an error when trying to send a Telegram message:
+
+```json
+{
+  "status": "error",
+  "tool": "message",
+  "error": "Unknown target \"+44790...\" for Telegram. Hint: <chatId>"
+}
+```
+
+**Cause:** Telegram bots identify users by numeric **chat ID**, not by phone number. Phone numbers cannot be used as a target for the Telegram Bot API. If you configured a contact or allowlist entry using a phone number (e.g., `+447901234567`), Telegram will not be able to resolve it.
+
+**Fix:** Use the numeric Telegram chat ID instead of a phone number. To find your chat ID:
+
+1. Open your bot in Telegram and send it any message.
+2. The bot replies with a pairing prompt that includes your **Telegram user id** (e.g., `123456789`).
+3. Use that numeric ID wherever a Telegram target is required (e.g., in `DM_ALLOWLIST` or tool calls).
+
+If you already have a conversation with the bot, you can also find your chat ID by checking the service logs:
+
+```bash
+sudo journalctl -u moltbot-gateway -n 50 --no-pager | grep -i "chat"
+```
+
 ### "Missing config" crash loop
 
 **Symptom:** The service starts, runs for ~15 seconds, then exits. The journal shows:


### PR DESCRIPTION
## Summary
Updated documentation and configuration templates to clarify that Telegram requires numeric chat IDs rather than phone numbers for identifying users, addressing a common source of confusion.

## Changes
- **deploy/moltbot.env.template**: Updated `DM_ALLOWLIST` comment to specify that Telegram requires numeric chat IDs instead of phone numbers
- **docs/TELEGRAM_SETUP.md**: Added new section "Telegram Uses Chat IDs, Not Phone Numbers" explaining the difference and how to find your chat ID
- **docs/TROUBLESHOOTING.md**: Added comprehensive troubleshooting entry for the "Unknown target" error on Telegram, including:
  - Clear symptom description with example error message
  - Root cause explanation
  - Step-by-step fix instructions
  - Alternative method to find chat ID via service logs

## Implementation Details
The changes provide users with:
1. Clear upfront guidance in the config template about platform-specific identifier formats
2. Dedicated documentation section in the Telegram setup guide
3. Practical troubleshooting steps for users who encounter the error
4. Multiple methods to discover the correct chat ID (pairing prompt or logs)

This addresses a usability gap where users familiar with other messaging platforms might assume phone numbers work universally.

https://claude.ai/code/session_01AXUZEWXVH7GCaUGjQcjfB2