### PR TITLE
Add clawd directory setup for moltbot-gateway service

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -165,6 +165,8 @@ create_moltbot_user() {
     mkdir -p "${MOLTBOT_HOME}/.npm-global"
     mkdir -p "${MOLTBOT_HOME}/.clawdbot"
     chmod 700 "${MOLTBOT_HOME}/.clawdbot"
+    mkdir -p "${MOLTBOT_HOME}/clawd"
+    chmod 700 "${MOLTBOT_HOME}/clawd"
 
     # Set npm global prefix for the moltbot user
     # Write .npmrc directly to avoid sudo HOME environment issues
@@ -268,7 +270,7 @@ Environment=NODE_OPTIONS=--max-old-space-size=${NODE_HEAP_SIZE}
 Environment=PATH=${MOLTBOT_HOME}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=${MOLTBOT_HOME}
 EnvironmentFile=-${MOLTBOT_CONFIG_DIR}/.env
-ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x ${MOLTBOT_HOME}/.npm-global/bin/moltbot || { echo "FATAL: ${MOLTBOT_HOME}/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f ${MOLTBOT_CONFIG_DIR}/.env || echo "WARN: ${MOLTBOT_CONFIG_DIR}/.env not found, running without env file" && mkdir -p ${MOLTBOT_HOME}/.clawdbot && chmod 700 ${MOLTBOT_HOME}/.clawdbot'
+ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x ${MOLTBOT_HOME}/.npm-global/bin/moltbot || { echo "FATAL: ${MOLTBOT_HOME}/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f ${MOLTBOT_CONFIG_DIR}/.env || echo "WARN: ${MOLTBOT_CONFIG_DIR}/.env not found, running without env file" && mkdir -p ${MOLTBOT_HOME}/.clawdbot && chmod 700 ${MOLTBOT_HOME}/.clawdbot && mkdir -p ${MOLTBOT_HOME}/clawd && chmod 700 ${MOLTBOT_HOME}/clawd'
 ExecStart=${MOLTBOT_HOME}/.npm-global/bin/moltbot gateway --port ${MOLTBOT_PORT}
 Restart=always
 RestartSec=10
@@ -281,7 +283,7 @@ NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=${MOLTBOT_CONFIG_DIR} ${MOLTBOT_DATA_DIR} ${MOLTBOT_HOME}/.npm-global ${MOLTBOT_HOME}/.clawdbot
+ReadWritePaths=${MOLTBOT_CONFIG_DIR} ${MOLTBOT_DATA_DIR} ${MOLTBOT_HOME}/.npm-global ${MOLTBOT_HOME}/.clawdbot ${MOLTBOT_HOME}/clawd
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes

--- a/deploy/moltbot-gateway.service
+++ b/deploy/moltbot-gateway.service
@@ -14,7 +14,7 @@ Environment=NODE_OPTIONS=--max-old-space-size=1536
 Environment=PATH=/home/moltbot/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=/home/moltbot
 EnvironmentFile=-/home/moltbot/.config/moltbot/.env
-ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x /home/moltbot/.npm-global/bin/moltbot || { echo "FATAL: /home/moltbot/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f /home/moltbot/.config/moltbot/.env || echo "WARN: /home/moltbot/.config/moltbot/.env not found, running without env file" && mkdir -p /home/moltbot/.clawdbot && chmod 700 /home/moltbot/.clawdbot'
+ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x /home/moltbot/.npm-global/bin/moltbot || { echo "FATAL: /home/moltbot/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f /home/moltbot/.config/moltbot/.env || echo "WARN: /home/moltbot/.config/moltbot/.env not found, running without env file" && mkdir -p /home/moltbot/.clawdbot && chmod 700 /home/moltbot/.clawdbot && mkdir -p /home/moltbot/clawd && chmod 700 /home/moltbot/clawd'
 ExecStart=/home/moltbot/.npm-global/bin/moltbot gateway --port 18789
 Restart=always
 RestartSec=10
@@ -27,7 +27,7 @@ NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/home/moltbot/.config/moltbot /home/moltbot/.local/share/moltbot /home/moltbot/.npm-global /home/moltbot/.clawdbot
+ReadWritePaths=/home/moltbot/.config/moltbot /home/moltbot/.local/share/moltbot /home/moltbot/.npm-global /home/moltbot/.clawdbot /home/moltbot/clawd
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes


### PR DESCRIPTION
## Summary
This PR adds setup and configuration for a new `clawd` directory in the moltbot home directory, ensuring it is created with proper permissions during installation and service startup.

## Changes
- **Installation script (`deploy/install.sh`)**: Added creation of `${MOLTBOT_HOME}/clawd` directory with `700` permissions during the `create_moltbot_user()` function
- **Service pre-start checks**: Updated `ExecStartPre` in both the install script template and the static service file to create the `clawd` directory with proper permissions if it doesn't exist
- **Service permissions**: Added `${MOLTBOT_HOME}/clawd` to the `ReadWritePaths` configuration in systemd service to allow the moltbot-gateway service write access to this directory

## Implementation Details
- The `clawd` directory is created with `700` permissions (read, write, execute for owner only) to match the security posture of the existing `.clawdbot` directory
- Directory creation is performed both during initial installation and as a pre-start check in the systemd service, ensuring it exists even if manually deleted
- The directory is explicitly added to systemd's `ReadWritePaths` to maintain strict filesystem isolation while allowing necessary write access

https://claude.ai/code/session_01J8DfZdWWRdPsZCuzPAF9FJ