### PR TITLE
Add /usr/local/bin symlink for moltbot CLI accessibility

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -245,6 +245,10 @@ install_moltbot() {
         exit 1
     fi
 
+    # Create a symlink in /usr/local/bin so that `moltbot` is on the default
+    # PATH for all users and shell types (login, non-login, sudo without -i).
+    ln -sf "${MOLTBOT_HOME}/.npm-global/bin/moltbot" /usr/local/bin/moltbot
+
     log_success "Moltbot installed at ${MOLTBOT_HOME}/.npm-global/bin/moltbot"
     sudo -u "$MOLTBOT_USER" -i moltbot --version || true
 }

--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -76,6 +76,17 @@ remove_sudoers() {
     fi
 }
 
+remove_symlink() {
+    log_info "Removing /usr/local/bin/moltbot symlink..."
+
+    if [[ -L /usr/local/bin/moltbot ]]; then
+        rm /usr/local/bin/moltbot
+        log_success "Symlink removed"
+    else
+        log_info "Symlink not found"
+    fi
+}
+
 remove_user() {
     log_info "Removing moltbot user..."
 
@@ -104,6 +115,7 @@ main() {
     remove_service
     remove_firewall_rule
     remove_sudoers
+    remove_symlink
     remove_user
 
     echo ""

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -50,6 +50,10 @@ update_moltbot() {
 
     remove_temp_swap
 
+    # Refresh the /usr/local/bin symlink so it always points at the current
+    # binary (path is stable, but this is cheap insurance after reinstall).
+    ln -sf "/home/${MOLTBOT_USER}/.npm-global/bin/moltbot" /usr/local/bin/moltbot
+
     NEW_VERSION=$(get_current_version)
     log_success "Updated to version: ${NEW_VERSION}"
 }


### PR DESCRIPTION
## Summary
This PR improves the accessibility of the moltbot CLI by creating a symlink in `/usr/local/bin`, ensuring the `moltbot` command is available on the default PATH for all users and shell types (login, non-login, and sudo without -i).

## Changes
- **install.sh**: Added symlink creation during installation that points `/usr/local/bin/moltbot` to the npm global binary location
- **uninstall.sh**: Added `remove_symlink()` function to clean up the symlink during uninstallation
- **update.sh**: Added symlink refresh during updates to ensure it always points to the current binary after reinstallation

## Implementation Details
- Uses `ln -sf` (force symbolic link) to safely create/overwrite the symlink
- The symlink approach avoids PATH modifications and works consistently across different shell configurations
- Symlink removal checks if the file is actually a symlink (`-L` test) before attempting deletion to prevent accidental removal of regular files
- Update process refreshes the symlink as a safety measure after binary reinstallation, though the path remains stable

https://claude.ai/code/session_019SaVMLZ1ouAwnuz5isJS3b