### PR TITLE
Add SSH config file documentation for gateway tunnel setup

### DIFF
--- a/docs/GATEWAY_UI.md
+++ b/docs/GATEWAY_UI.md
@@ -102,6 +102,34 @@ ssh -L 18789:127.0.0.1:18789 user@your-vm-ip
 
 Then visit `http://localhost:18789` in your browser. The gateway traffic is encrypted through the SSH connection.
 
+#### SSH Config File
+
+To avoid typing the tunnel flags every time, add an entry to your local `~/.ssh/config` file:
+
+```
+Host moltbot
+  Hostname <ip-address>
+  User <user>
+  IdentityFile ~/.ssh/moltbot
+  IdentitiesOnly yes
+  # This maps your local port 18789 to the remote port 18789
+  LocalForward 127.0.0.1:18789 localhost:18789
+  # Optional: keeps the connection alive
+  ServerAliveInterval 60
+  # Force IPv4 to avoid the [::1] bind error
+  AddressFamily inet
+```
+
+Replace `<ip-address>` with your VPS public IP and `<user>` with your SSH username. The `IdentityFile` line assumes you have a dedicated SSH key at `~/.ssh/moltbot`; adjust the path if your key is elsewhere.
+
+With this in place, connect and forward the gateway port in one command:
+
+```bash
+ssh moltbot
+```
+
+Then visit `http://localhost:18789` in your browser as usual.
+
 ### Reverse Proxy
 
 Place the gateway behind a reverse proxy (nginx, Caddy) with TLS termination for HTTPS access. See the official documentation for configuration examples: [Gateway security](https://docs.molt.bot/gateway/security).


### PR DESCRIPTION
## Summary
Added documentation for configuring SSH tunneling to the gateway UI using an SSH config file, providing a more convenient alternative to manually typing tunnel flags each time.

## Changes
- Added new "SSH Config File" subsection under the SSH tunneling documentation
- Provided a complete example SSH config entry with all necessary parameters:
  - Host alias configuration for easy connection
  - LocalForward mapping for port 18789
  - ServerAliveInterval to maintain connection stability
  - AddressFamily inet to prevent IPv6 binding issues
- Included instructions for customizing the config with user's IP address and SSH username
- Documented the simplified connection command (`ssh moltbot`) that replaces the longer manual tunnel command
- Added note about IdentityFile path flexibility for different key locations

## Implementation Details
The documentation includes practical configuration options that address common issues:
- The `AddressFamily inet` setting prevents the `[::1] bind error` mentioned in the comment
- `ServerAliveInterval 60` helps maintain long-lived connections
- `IdentitiesOnly yes` improves security by limiting key attempts
- Clear placeholder syntax (`<ip-address>`, `<user>`) makes customization obvious

https://claude.ai/code/session_019xUYYR8CpXFPm3VWepZwWk