### PR TITLE
Refactor systemd pre-start checks to run with elevated privileges

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -274,7 +274,8 @@ Environment=NODE_OPTIONS=--max-old-space-size=${NODE_HEAP_SIZE}
 Environment=PATH=${MOLTBOT_HOME}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=${MOLTBOT_HOME}
 EnvironmentFile=-${MOLTBOT_CONFIG_DIR}/.env
-ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x ${MOLTBOT_HOME}/.npm-global/bin/moltbot || { echo "FATAL: ${MOLTBOT_HOME}/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f ${MOLTBOT_CONFIG_DIR}/.env || echo "WARN: ${MOLTBOT_CONFIG_DIR}/.env not found, running without env file" && mkdir -p ${MOLTBOT_HOME}/.clawdbot && chmod 700 ${MOLTBOT_HOME}/.clawdbot && mkdir -p ${MOLTBOT_HOME}/clawd && chmod 700 ${MOLTBOT_HOME}/clawd'
+ExecStartPre=+/bin/sh -c 'mkdir -p ${MOLTBOT_HOME}/.clawdbot ${MOLTBOT_HOME}/clawd && chown ${MOLTBOT_USER}:${MOLTBOT_USER} ${MOLTBOT_HOME}/.clawdbot ${MOLTBOT_HOME}/clawd && chmod 700 ${MOLTBOT_HOME}/.clawdbot ${MOLTBOT_HOME}/clawd'
+ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x ${MOLTBOT_HOME}/.npm-global/bin/moltbot || { echo "FATAL: ${MOLTBOT_HOME}/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f ${MOLTBOT_CONFIG_DIR}/.env || echo "WARN: ${MOLTBOT_CONFIG_DIR}/.env not found, running without env file"'
 ExecStart=${MOLTBOT_HOME}/.npm-global/bin/moltbot gateway --port ${MOLTBOT_PORT}
 Restart=always
 RestartSec=10

--- a/deploy/moltbot-gateway.service
+++ b/deploy/moltbot-gateway.service
@@ -14,7 +14,8 @@ Environment=NODE_OPTIONS=--max-old-space-size=1536
 Environment=PATH=/home/moltbot/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=/home/moltbot
 EnvironmentFile=-/home/moltbot/.config/moltbot/.env
-ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x /home/moltbot/.npm-global/bin/moltbot || { echo "FATAL: /home/moltbot/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f /home/moltbot/.config/moltbot/.env || echo "WARN: /home/moltbot/.config/moltbot/.env not found, running without env file" && mkdir -p /home/moltbot/.clawdbot && chmod 700 /home/moltbot/.clawdbot && mkdir -p /home/moltbot/clawd && chmod 700 /home/moltbot/clawd'
+ExecStartPre=+/bin/sh -c 'mkdir -p /home/moltbot/.clawdbot /home/moltbot/clawd && chown moltbot:moltbot /home/moltbot/.clawdbot /home/moltbot/clawd && chmod 700 /home/moltbot/.clawdbot /home/moltbot/clawd'
+ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x /home/moltbot/.npm-global/bin/moltbot || { echo "FATAL: /home/moltbot/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f /home/moltbot/.config/moltbot/.env || echo "WARN: /home/moltbot/.config/moltbot/.env not found, running without env file"'
 ExecStart=/home/moltbot/.npm-global/bin/moltbot gateway --port 18789
 Restart=always
 RestartSec=10


### PR DESCRIPTION
## Summary
Refactored the moltbot-gateway systemd service pre-start checks to separate directory initialization from validation logic. The directory creation and ownership setup now runs with elevated privileges (root), while validation checks run as the moltbot user.

## Key Changes
- Split `ExecStartPre` into two separate commands:
  - First command (with `+` prefix): Runs as root to create directories and set proper ownership/permissions
  - Second command: Runs as moltbot user to validate binary and configuration file existence
- Moved `mkdir`, `chown`, and `chmod` operations to the elevated privilege command
- Removed redundant directory operations from the validation command
- Applied changes to both the install script template and the actual service file

## Implementation Details
- The `+` prefix in systemd allows the first `ExecStartPre` to run with elevated privileges even when the main service runs as an unprivileged user
- This ensures directories are properly owned by the moltbot user before the service starts
- Validation checks remain in the second command to fail fast if the binary or config is missing
- Both `.clawdbot` and `clawd` directories are now guaranteed to have correct ownership and 700 permissions

https://claude.ai/code/session_01Lmr1Kqfa6YYaPVevfpPeAZ