### PR TITLE
Pre-create ~/clawd/memory/ directory for agent daily notes

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -165,7 +165,7 @@ create_moltbot_user() {
     mkdir -p "${MOLTBOT_HOME}/.npm-global"
     mkdir -p "${MOLTBOT_HOME}/.clawdbot"
     chmod 700 "${MOLTBOT_HOME}/.clawdbot"
-    mkdir -p "${MOLTBOT_HOME}/clawd"
+    mkdir -p "${MOLTBOT_HOME}/clawd/memory"
     chmod 700 "${MOLTBOT_HOME}/clawd"
 
     # Set npm global prefix for the moltbot user
@@ -274,7 +274,7 @@ Environment=NODE_OPTIONS=--max-old-space-size=${NODE_HEAP_SIZE}
 Environment=PATH=${MOLTBOT_HOME}/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=${MOLTBOT_HOME}
 EnvironmentFile=-${MOLTBOT_CONFIG_DIR}/.env
-ExecStartPre=+/bin/sh -c 'mkdir -p ${MOLTBOT_HOME}/.clawdbot ${MOLTBOT_HOME}/clawd && chown ${MOLTBOT_USER}:${MOLTBOT_USER} ${MOLTBOT_HOME}/.clawdbot ${MOLTBOT_HOME}/clawd && chmod 700 ${MOLTBOT_HOME}/.clawdbot ${MOLTBOT_HOME}/clawd'
+ExecStartPre=+/bin/sh -c 'mkdir -p ${MOLTBOT_HOME}/.clawdbot ${MOLTBOT_HOME}/clawd/memory && chown -R ${MOLTBOT_USER}:${MOLTBOT_USER} ${MOLTBOT_HOME}/.clawdbot ${MOLTBOT_HOME}/clawd && chmod 700 ${MOLTBOT_HOME}/.clawdbot ${MOLTBOT_HOME}/clawd'
 ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x ${MOLTBOT_HOME}/.npm-global/bin/moltbot || { echo "FATAL: ${MOLTBOT_HOME}/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f ${MOLTBOT_CONFIG_DIR}/.env || echo "WARN: ${MOLTBOT_CONFIG_DIR}/.env not found, running without env file"'
 ExecStart=${MOLTBOT_HOME}/.npm-global/bin/moltbot gateway --port ${MOLTBOT_PORT}
 Restart=always

--- a/deploy/moltbot-gateway.service
+++ b/deploy/moltbot-gateway.service
@@ -14,7 +14,7 @@ Environment=NODE_OPTIONS=--max-old-space-size=1536
 Environment=PATH=/home/moltbot/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=/home/moltbot
 EnvironmentFile=-/home/moltbot/.config/moltbot/.env
-ExecStartPre=+/bin/sh -c 'mkdir -p /home/moltbot/.clawdbot /home/moltbot/clawd && chown moltbot:moltbot /home/moltbot/.clawdbot /home/moltbot/clawd && chmod 700 /home/moltbot/.clawdbot /home/moltbot/clawd'
+ExecStartPre=+/bin/sh -c 'mkdir -p /home/moltbot/.clawdbot /home/moltbot/clawd/memory && chown -R moltbot:moltbot /home/moltbot/.clawdbot /home/moltbot/clawd && chmod 700 /home/moltbot/.clawdbot /home/moltbot/clawd'
 ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x /home/moltbot/.npm-global/bin/moltbot || { echo "FATAL: /home/moltbot/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f /home/moltbot/.config/moltbot/.env || echo "WARN: /home/moltbot/.config/moltbot/.env not found, running without env file"'
 ExecStart=/home/moltbot/.npm-global/bin/moltbot gateway --port 18789
 Restart=always


### PR DESCRIPTION
The OpenClaw agent expects ~/clawd/memory/ to exist for storing daily
notes. Like the parent clawd/ directory, this subdirectory must be
created on the real filesystem before the ProtectHome=read-only
namespace is applied, otherwise the mkdir at runtime fails against the
read-only mount.

Changes:
- install.sh: mkdir -p clawd/memory (implicitly creates both levels)
- ExecStartPre (privileged): create clawd/memory and chown -R so the
  subdirectory inherits moltbot ownership

https://claude.ai/code/session_01HXijuvcjCrJXSfp9yHMNQp