### PR TITLE
docs: Add official OpenClaw documentation links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,3 +56,25 @@ There is no build step or test suite — this is a scripts-and-docs repository.
 - **Service**: `moltbot-gateway` systemd unit on port 18789
 - **Security**: `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=read-only`, dedicated user
 - **Low-memory**: Auto-tunes `MemoryMax` and `--max-old-space-size`; temporary swap for installs on <4 GB RAM; minimum 2 GB RAM enforced by installer
+
+## Official Documentation Links
+
+For solving problems and understanding OpenClaw/Moltbot features, refer to the official documentation:
+
+### Core Resources
+- **[OpenClaw Documentation](https://docs.openclaw.ai/)** — Main documentation hub (index, architecture, configuration reference)
+- **[OpenClaw GitHub](https://github.com/openclaw/openclaw)** — Source code, issues, and discussions
+- **[OpenClaw Website](https://openclaw.ai/)** — Product overview and features
+
+### Relevant Documentation Sections
+- **[Gateway UI Guide](https://docs.openclaw.ai/)** — Browser control panel (chat, config, nodes, sessions)
+- **[Channel Configuration](https://docs.openclaw.ai/)** — WhatsApp, Telegram, Discord, Slack, Signal, iMessage, Teams, Matrix, and other channel setup
+- **[Installation & Onboarding](https://docs.openclaw.ai/)** — Global npm install, configuration, service management
+- **[Architecture Overview](https://docs.openclaw.ai/)** — Gateway + protocol model, design patterns
+- **[Configuration Reference](https://docs.openclaw.ai/)** — Complete environment variables and settings
+
+### Related Deployment Guides
+- **[README.md](README.md)** — Quick start and deployment instructions
+- **[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md)** — Multi-platform deployment options
+- **[docs/SECURITY.md](docs/SECURITY.md)** — Security hardening and risk assessment
+- **[docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)** — Common issues and solutions

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Deployment scripts and configuration for running [Moltbot](https://molt.bot) (fo
 
 Moltbot is a personal AI assistant that runs on your own hardware. It connects to messaging platforms you already use (WhatsApp, Telegram, Slack, Discord, etc.) and can perform tasks, manage your calendar, browse the web, organize files, and run terminal commands.
 
-- **Documentation**: https://docs.molt.bot
-- **GitHub**: https://github.com/moltbot/moltbot
+- **Official Documentation**: https://docs.openclaw.ai
+- **Moltbot Documentation**: https://docs.molt.bot
+- **GitHub**: https://github.com/openclaw/openclaw
 
 ## Prerequisites
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,10 +2,15 @@
 
 Welcome to the Moltbot documentation. This directory contains guides for use cases, deployment options, security, community applications, and cost information.
 
+## Official Documentation
+
+The primary source for OpenClaw/Moltbot documentation is:
+- **[OpenClaw Documentation](https://docs.openclaw.ai)** — Main documentation hub with index, architecture, installation, and configuration reference
+
 ## Quick Links
 
 ### Getting Started
-- **[Official Documentation](https://docs.molt.bot/start/getting-started)** - Complete getting started guide
+- **[Official Getting Started Guide](https://docs.openclaw.ai)** - Complete installation and onboarding
 - **[Deployment Guide](./DEPLOYMENT.md)** - How to deploy Moltbot across different platforms
 
 ### Understanding Moltbot


### PR DESCRIPTION
Add links to https://docs.openclaw.ai/ in CLAUDE.md, README.md, and
docs/README.md to help AI assistants and users find the official
documentation for OpenClaw/Moltbot features, architecture, configuration,
and troubleshooting.

Updates:
- CLAUDE.md: New "Official Documentation Links" section with core resources
  and relevant documentation sections
- README.md: Clarify OpenClaw as the primary product with link to official
  docs and Moltbot docs
- docs/README.md: Add "Official Documentation" section at the top directing
  to docs.openclaw.ai

https://claude.ai/code/session_01DRv91bZp9FjuMLhQ4MFPQN