### PR TITLE
fix: prevent world-writable files and directories (#55)

### DIFF
--- a/deploy/moltbot-gateway.service
+++ b/deploy/moltbot-gateway.service
@@ -14,7 +14,7 @@ Environment=NODE_OPTIONS=--max-old-space-size=1536
 Environment=PATH=/home/moltbot/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 Environment=HOME=/home/moltbot
 EnvironmentFile=-/home/moltbot/.config/moltbot/.env
-ExecStartPre=+/bin/sh -c 'mkdir -p /home/moltbot/.clawdbot /home/moltbot/clawd/memory && chown -R moltbot:moltbot /home/moltbot/.clawdbot /home/moltbot/clawd && chmod 700 /home/moltbot/.clawdbot /home/moltbot/clawd'
+ExecStartPre=+/bin/sh -c 'umask 0077 && mkdir -p /home/moltbot/.clawdbot /home/moltbot/clawd/memory && chown -R moltbot:moltbot /home/moltbot/.clawdbot /home/moltbot/clawd && chmod -R 700 /home/moltbot/.clawdbot /home/moltbot/clawd'
 ExecStartPre=/bin/sh -c 'echo "moltbot-gateway: pre-start checks..." && test -x /home/moltbot/.npm-global/bin/moltbot || { echo "FATAL: /home/moltbot/.npm-global/bin/moltbot not found or not executable"; exit 1; } && test -f /home/moltbot/.config/moltbot/.env || echo "WARN: /home/moltbot/.config/moltbot/.env not found, running without env file"'
 ExecStart=/home/moltbot/.npm-global/bin/moltbot gateway --port 18789
 Restart=always


### PR DESCRIPTION
Set secure umask (0077) before creating state directories and add
explicit chmod commands for all created files to prevent world-writable
permissions.

Changes:
- Add umask 0077 before mkdir operations in deploy.sh and systemd service
- Add chmod -R 700 for .clawdbot and clawd state directories
- Add chmod 644 for shell config files (.npmrc, .profile, .bashrc)
- Add chmod 644 for template files (moltbot.env.template, moltbot.fallbacks.json)
- Keep chmod 600 for sensitive .env file containing API keys

Fixes #55

https://claude.ai/code/session_01V3QahkgiRpzdq3muK7k7Zh