### PR TITLE
docs: add troubleshooting entry for Telegram Gateway UI schema error (#57)

### DIFF
--- a/docs/TELEGRAM_SETUP.md
+++ b/docs/TELEGRAM_SETUP.md
@@ -34,6 +34,8 @@ TELEGRAM_BOT_TOKEN=123456789:ABCdefGhIjKlMnOpQrStUvWxYz
 
 The env file is loaded by the systemd service via the `EnvironmentFile` directive in `moltbot-gateway.service`. It should already have `chmod 600` permissions (set by the installer), so the token is readable only by the `moltbot` user.
 
+> **Known issue:** The Gateway UI may show an "Unsupported schema node. Use Raw mode" error when trying to configure Telegram settings ([issue #57](https://github.com/Joe-Heffer/moltbot/issues/57)). This is a UI rendering bug. The workaround is to configure Telegram via the `.env` file as shown above, rather than using the Gateway web interface. See the [Troubleshooting Guide](./TROUBLESHOOTING.md#unsupported-schema-node-error-in-gateway-ui-for-telegram) for details.
+
 ## Step 3: Restart the Service
 
 ```bash

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -87,6 +87,37 @@ sudo systemctl restart moltbot-gateway
 
 The bot will now respond to all Telegram messages without requiring approval. Switch back to `DM_POLICY=pairing` once a fixed version is released. See the [Telegram Setup Guide](./TELEGRAM_SETUP.md#workaround-set-dm_policyopen) for details.
 
+### "Unsupported schema node" error in Gateway UI for Telegram
+
+**Symptom:** When configuring Telegram settings in the Gateway UI web interface, you see an error message:
+
+```
+Accounts / Unsupported schema node. Use Raw mode.
+```
+
+**Cause:** This is a bug in the Gateway UI's schema-based form rendering system (tracked in [issue #57](https://github.com/Joe-Heffer/moltbot/issues/57)). The UI encounters a schema node type it doesn't know how to render for Telegram account configuration.
+
+**Workaround:** Configure Telegram directly via the environment file instead of using the Gateway UI:
+
+1. SSH into your server and edit the environment file:
+   ```bash
+   sudo -u moltbot nano /home/moltbot/.config/moltbot/.env
+   ```
+
+2. Add or uncomment the Telegram configuration:
+   ```bash
+   TELEGRAM_BOT_TOKEN=your_bot_token_here
+   ```
+
+3. Restart the service to apply changes:
+   ```bash
+   sudo systemctl restart moltbot-gateway
+   ```
+
+See the [Telegram Setup Guide](./TELEGRAM_SETUP.md) for detailed instructions on obtaining a bot token from @BotFather and configuring security settings.
+
+Alternatively, if the Gateway UI offers a "Raw mode" option for the Telegram configuration, you can click that to edit the configuration as JSON directly instead of using the form-based interface.
+
 ### "Unknown target" phone number error on Telegram
 
 **Symptom:** OpenClaw returns an error when trying to send a Telegram message:


### PR DESCRIPTION
Document the "Unsupported schema node" error that appears when
configuring Telegram settings in the Gateway UI web interface.
Provide workaround using .env file configuration instead of the UI.

- Add troubleshooting section for Gateway UI schema rendering bug
- Update Telegram setup guide with known issue note
- Link to issue #57 for tracking
- Reference workaround in both TROUBLESHOOTING.md and TELEGRAM_SETUP.md

Resolves #57

https://claude.ai/code/session_01U5rYm7CPm5BaccP4g9NjEY