### PR TITLE
fix: remove automatic firewall port opening for security (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ The `deploy.sh` script is idempotent — it handles both first-time installation
 3. Creates a dedicated `moltbot` user for security
 4. Installs or updates moltbot globally via npm
 5. Regenerates the systemd service (so configuration changes always propagate)
-6. Opens port 18789 in the firewall (if firewalld is active)
-7. Sets up AI provider fallback configuration (automatic retry on failures)
+6. Sets up AI provider fallback configuration (automatic retry on failures)
 
 If the service was already running (i.e. this is an update), it restarts the service, runs a health check, and executes `moltbot doctor --repair`. On first install, it prints onboarding instructions instead.
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -427,21 +427,6 @@ EOF
     log_success "Systemd service configured"
 }
 
-configure_firewall() {
-    log_info "Configuring firewall..."
-
-    if systemctl is-active --quiet firewalld 2>/dev/null; then
-        firewall-cmd --permanent --add-port="${MOLTBOT_PORT}/tcp"
-        firewall-cmd --reload
-        log_success "Firewall configured via firewalld (port ${MOLTBOT_PORT} opened)"
-    elif command -v ufw &> /dev/null && ufw status | grep -q "active"; then
-        ufw allow "${MOLTBOT_PORT}/tcp"
-        log_success "Firewall configured via ufw (port ${MOLTBOT_PORT} opened)"
-    else
-        log_warn "No active firewall detected, skipping firewall configuration"
-    fi
-}
-
 copy_env_template() {
     log_info "Creating environment template..."
 
@@ -667,9 +652,6 @@ main() {
 
     DEPLOY_PHASE="systemd setup"
     setup_systemd_service
-
-    DEPLOY_PHASE="firewall configuration"
-    configure_firewall
 
     DEPLOY_PHASE="environment template"
     copy_env_template

--- a/deploy/uninstall.sh
+++ b/deploy/uninstall.sh
@@ -51,20 +51,6 @@ remove_service() {
     fi
 }
 
-remove_firewall_rule() {
-    log_info "Removing firewall rule..."
-
-    if systemctl is-active --quiet firewalld; then
-        if firewall-cmd --list-ports | grep -q "${MOLTBOT_PORT}/tcp"; then
-            firewall-cmd --permanent --remove-port="${MOLTBOT_PORT}/tcp"
-            firewall-cmd --reload
-            log_success "Firewall rule removed"
-        else
-            log_info "Firewall rule not found"
-        fi
-    fi
-}
-
 remove_sudoers() {
     log_info "Removing deploy sudoers rules..."
 
@@ -113,7 +99,6 @@ main() {
 
     stop_service
     remove_service
-    remove_firewall_rule
     remove_sudoers
     remove_symlink
     remove_user

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -25,7 +25,9 @@ cd moltbot
 sudo ./deploy/deploy.sh
 ```
 
-The deploy script handles Node.js 22 installation, dedicated user creation, systemd service setup, firewall configuration, and resource tuning. It is idempotent — safe to run for both first-time installation and subsequent updates. After first installation, run the onboarding wizard to configure API keys and channels.
+The deploy script handles Node.js 22 installation, dedicated user creation, systemd service setup, and resource tuning. It is idempotent — safe to run for both first-time installation and subsequent updates. After first installation, run the onboarding wizard to configure API keys and channels.
+
+**Note:** Firewall configuration is not automated. You must manually configure your firewall to allow traffic on port 18789 (see [Gateway UI Setup Guide](GATEWAY_UI.md#firewall)).
 
 **CI/CD deployment:**
 

--- a/docs/GATEWAY_UI.md
+++ b/docs/GATEWAY_UI.md
@@ -124,13 +124,13 @@ sudo systemctl restart moltbot-gateway
 
 ### Firewall
 
-The installer opens port 18789 automatically when firewalld is active. If you use a different firewall (e.g. `ufw`), allow the port manually:
+You must manually configure your firewall to allow traffic on port 18789. The installer does not automatically open firewall ports for security reasons.
 
 ```bash
 # ufw
 sudo ufw allow 18789/tcp
 
-# firewalld (if not already opened by the installer)
+# firewalld
 sudo firewall-cmd --permanent --add-port=18789/tcp
 sudo firewall-cmd --reload
 ```


### PR DESCRIPTION
Remove automated firewall configuration from deployment scripts as it is
too sensitive to automate. Users must now manually configure their
firewall to allow traffic on port 18789.

Changes:
- Remove configure_firewall() function from deploy/deploy.sh
- Remove remove_firewall_rule() function from uninstall.sh
- Update documentation to clarify manual firewall configuration is required
- Add note in docs/DEPLOYMENT.md with link to firewall setup instructions

Closes #80

https://claude.ai/code/session_01SeU8SCvWxeaJJpd8sF27sH