### PR TITLE
fix: move version tracking into deploy.sh to avoid sudo password error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,10 +98,13 @@ jobs:
 
             set -e
 
-            # Save deployment version for tracking
-            echo "Deployed version: ${{ steps.version.outputs.version }}"
-            echo "${{ steps.version.outputs.version }}" | sudo tee /opt/moltbot-version > /dev/null
-            sudo chown ${{ env.MOLTBOT_USER }}:${{ env.MOLTBOT_USER }} /opt/moltbot-version
+            # Version tracking: deploy.sh saves /opt/moltbot-version when
+            # ACTION=deploy.  For restarts the existing file is still valid.
+            if [ -f /opt/moltbot-version ]; then
+              echo "Deployed version: $(cat /opt/moltbot-version)"
+            else
+              echo "Deployed version: ${{ steps.version.outputs.version }} (not yet saved)"
+            fi
 
             # Always show status (even on failure, for diagnostics)
             echo ""


### PR DESCRIPTION
The deploy workflow used `sudo tee` and `sudo chown` to write
/opt/moltbot-version, but these commands were not covered by the
deploy user's NOPASSWD sudoers rules. In the non-interactive SSH
session this caused:

  "a terminal is required to read the password"

Move version tracking into deploy.sh which already runs as root and
can write the file directly. The workflow now reads the file instead
of writing it.

Closes #79

https://claude.ai/code/session_01TMtW1x5oFhgjgTdgvAanYi