### PR TITLE
docs: split documentation into modular files for better navigation and reduced token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Deploy to VPS](https://github.com/Joe-Heffer/moltbot/actions/workflows/deploy.yml/badge.svg)](https://github.com/Joe-Heffer/moltbot/actions/workflows/deploy.yml)
 [![Lint](https://github.com/Joe-Heffer/moltbot/actions/workflows/lint.yml/badge.svg)](https://github.com/Joe-Heffer/moltbot/actions/workflows/lint.yml)
 
-Deployment scripts and configuration for running [OpenClaw](https://openclaw.ai) (formerly ClawdBot) on Linux VPS.
+Deployment scripts and configuration for running [OpenClaw](https://openclaw.ai) on Linux VPS.
 
 ## What is OpenClaw?
 
@@ -12,360 +12,148 @@ OpenClaw is a personal AI assistant that runs on your own hardware. It connects 
 - **Documentation**: https://docs.openclaw.ai
 - **GitHub**: https://github.com/openclaw/openclaw
 
-## Prerequisites
-
-- Ubuntu Linux 24.04 LTS
-- Root/sudo access
-- At least 2 GB RAM (4 GB recommended); see the [official system requirements](https://docs.openclaw.ai/help/faq)
-- An API key from [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), or [Google Gemini](https://aistudio.google.com/apikey)
-
-> **Low-memory VPS**: The installer automatically detects available RAM and
-> tunes `MemoryMax` and Node.js heap size accordingly. Systems with less than
-> 4 GB RAM should add swap space (see [Low-Memory VPS](#low-memory-vps) below).
-
 ## Quick Start
 
 ```bash
-# Clone this repository
 git clone https://github.com/Joe-Heffer/moltbot.git
 cd moltbot
-
-# Run the deployment script
 sudo ./deploy/deploy.sh
-
-# Run onboarding as the moltbot user
 sudo -u moltbot -i moltbot onboard
-
-# Start and enable the service
 sudo systemctl start moltbot-gateway
 sudo systemctl enable moltbot-gateway
 ```
 
-## Deployment Details
+Then access the Gateway UI at `http://<your-vm-ip>:18789`
 
-The `deploy.sh` script is idempotent — it handles both first-time installation and subsequent updates. On every run it:
+For detailed instructions, see **[Quick Start Guide](docs/QUICK_START.md)**.
 
-1. Installs system dependencies (curl, git, gcc, etc.)
-2. Installs Node.js 22 via NodeSource repository
-3. Creates a dedicated `moltbot` user for security
-4. Installs or updates moltbot globally via npm
-5. Regenerates the systemd service (so configuration changes always propagate)
-6. Sets up AI provider fallback configuration (automatic retry on failures)
+## Prerequisites
 
-If the service was already running (i.e. this is an update), it restarts the service, runs a health check, and executes `moltbot doctor --repair`. On first install, it prints onboarding instructions instead.
+- Ubuntu 24.04 LTS (Debian, RHEL, Oracle Linux also supported)
+- Root/sudo access
+- At least 2 GB RAM (4 GB recommended)
+- API key from [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), or [Google Gemini](https://aistudio.google.com/apikey)
 
-## Directory Structure
+## Documentation
 
-```
-deploy/
-├── deploy.sh               # Idempotent deployment script (install + update)
-├── setup-server.sh         # One-time server preparation for CI/CD
-├── uninstall.sh            # Removal script
-├── configure-fallbacks.sh  # AI provider fallback configuration script
-├── lib.sh                  # Shared library (logging, validation, memory tuning)
-├── moltbot-gateway.service # Systemd service file (reference)
-├── moltbot.env.template    # Environment variable template
-└── moltbot.fallbacks.json  # AI provider fallback configuration
+**Start here**: [Documentation Hub](docs/README.md) — Overview of all guides
 
-.github/workflows/
-├── deploy.yml              # GitHub Actions deployment workflow (with environment tracking)
-└── lint.yml                # ShellCheck, actionlint, yamllint
-```
+### Core Guides
+- **[Quick Start](docs/QUICK_START.md)** — Minimal steps to deploy (5-10 min)
+- **[Configuration](docs/CONFIGURATION.md)** — AI providers, environment variables, onboarding
+- **[Service Management](docs/SERVICE_MANAGEMENT.md)** — Start, stop, monitor, troubleshoot
+- **[Deployment Options](docs/DEPLOYMENT.md)** — VPS, local, Docker, NAS, and more
 
-## CI/CD Deployment (GitHub Actions)
+### Operations
+- **[GitHub Actions CI/CD](docs/GITHUB_ACTIONS_DEPLOYMENT.md)** — Automated deployment and updates
+- **[Low-Memory VPS](docs/LOW_MEMORY_VPS.md)** — Optimization for 2–4 GB RAM systems
+- **[Gateway UI Setup](docs/GATEWAY_UI.md)** — Web interface access and authentication
 
-For automated deployments to your VPS, use the included GitHub Actions workflow.
+### Security & Planning
+- **[Security Guide](docs/SECURITY.md)** — Hardening checklist and best practices
+- **[Public vs. Private Repo](docs/PUBLIC_VS_PRIVATE.md)** — Repository visibility considerations
+- **[Repository Structure](docs/REPOSITORY_STRUCTURE.md)** — Files and deployment scripts
+- **[Troubleshooting](docs/TROUBLESHOOTING.md)** — Common issues and solutions
 
-### One-Time Server Setup
+### Learning
+- **[Use Cases](docs/USE_CASES.md)** — Real-world applications
+- **[Cost Expectations](docs/COST_EXPECTATIONS.md)** — Pricing and budget planning
+- **[Community Applications](docs/COMMUNITY_APPLICATIONS.md)** — Examples from the community
 
-1. **SSH into your VPS** and run the server setup script:
+## What This Repository Does
 
+This repository provides:
+- **`deploy/deploy.sh`** — Idempotent deployment script (install + update)
+- **`deploy/setup-server.sh`** — CI/CD server preparation
+- **`deploy/lib.sh`** — Shared utilities (logging, validation, memory tuning)
+- **GitHub Actions workflows** — Automated deployment and semantic versioning
+- **Documentation** — Setup guides, security hardening, troubleshooting
+
+It does **not** contain the OpenClaw application itself (installed via `npm install -g moltbot`).
+
+## Automated Deployment (GitHub Actions)
+
+For CI/CD deployment to your VPS:
+
+1. Run one-time setup on VPS:
    ```bash
-   # Download and run setup script
-   curl -fsSL https://raw.githubusercontent.com/Joe-Heffer/moltbot/main/deploy/setup-server.sh -o setup-server.sh
-   chmod +x setup-server.sh
-   sudo ./setup-server.sh
+   sudo ./deploy/setup-server.sh
    ```
 
-   This creates a `deploy` user with limited sudo permissions for CI/CD.
+2. Add repository secrets (`VPS_HOST`, `VPS_USERNAME`, `VPS_SSH_KEY`, `VPS_PORT`)
 
-2. **Generate an SSH key pair** (on your local machine):
+3. Push to `main` branch or manually trigger workflow
 
-   ```bash
-   ssh-keygen -t ed25519 -C "github-actions-moltbot" -f ~/.ssh/moltbot-deploy
-   ```
+See **[GitHub Actions CI/CD Guide](docs/GITHUB_ACTIONS_DEPLOYMENT.md)** for details.
 
-3. **Add the public key to your server**:
+## Common Tasks
 
-   ```bash
-   # Copy to server
-   ssh-copy-id -i ~/.ssh/moltbot-deploy.pub deploy@your-server-ip
-   ```
-
-4. **Add GitHub repository secrets** at `Settings > Secrets > Actions`:
-
-   | Secret | Value |
-   |--------|-------|
-   | `VPS_HOST` | Your VPS IP address |
-   | `VPS_USERNAME` | `deploy` |
-   | `VPS_SSH_KEY` | Contents of `~/.ssh/moltbot-deploy` (private key) |
-   | `VPS_PORT` | `22` (or your custom SSH port) |
-
-### Deployment Triggers
-
-The workflow runs automatically when:
-- Changes are pushed to `main` branch in the `deploy/` directory
-- Manually triggered via GitHub Actions UI
-
-### Manual Deployment
-
-Go to `Actions` > `Deploy to VPS` > `Run workflow` and choose:
-
-| Action | Description |
-|--------|-------------|
-| `deploy` | Installs or updates moltbot and regenerates all configuration |
-| `restart` | Restarts the moltbot-gateway service |
-
-### Workflow Features
-
-- **Deployment tracking**: Each deploy is recorded in the GitHub Environments UI — view history, status, and the live commit under `Settings > Environments > production`
-- **Concurrency control**: Only one deployment runs at a time; subsequent triggers queue instead of overlapping
-- **Health checks**: Verifies service is running and port is listening after deploy
-- **Zero-downtime updates**: Service restarts only after successful update
-- **Automatic rollback info**: Logs previous version for easy rollback
-
-## Configuration
-
-### 1. Choose Your AI Provider
-
-Moltbot is **model-agnostic** and supports multiple AI providers. You can configure one or more:
-
-| Provider | Recommended Use | API Key Link | Notes |
-|----------|----------------|--------------|-------|
-| **Anthropic** | Production use | [console.anthropic.com](https://console.anthropic.com/) | Recommended - Claude Opus 4.5 offers best performance |
-| **OpenAI** | Alternative | [platform.openai.com](https://platform.openai.com/api-keys) | GPT-4 and GPT-3.5 models |
-| **Google Gemini** | Alternative | [aistudio.google.com](https://aistudio.google.com/apikey) | Gemini Pro and Ultra models |
-
-Unlike ChatGPT's usage limits, you control your own API keys and rate limits. Multiple providers can be configured simultaneously for redundancy.
-
-#### Automatic Failover
-
-The deployment automatically configures **model fallbacks** based on your available API keys:
-
-1. **Primary Model**: Anthropic Claude Opus 4.5 (if `ANTHROPIC_API_KEY` is set)
-2. **Fallback 1**: OpenAI GPT-4 (if `OPENAI_API_KEY` is set)
-3. **Fallback 2**: Google Gemini Pro (if `GEMINI_API_KEY` is set)
-
-If the primary model fails (rate limits, API errors, etc.), Moltbot automatically switches to the next available fallback. This ensures **continuous operation** even during API outages or rate limiting.
-
-**Customize Fallbacks**: Edit `~/.config/moltbot/moltbot.fallbacks.json` to change the provider priority or add additional models, then run:
-
+### Restart the Service
 ```bash
-sudo /opt/moltbot-deployment/deploy/configure-fallbacks.sh
-```
-
-### 2. Run Onboarding
-
-The onboarding wizard guides you through:
-- LLM provider setup (choose from Anthropic, OpenAI, or Google Gemini)
-- Workspace configuration
-- Channel connections (WhatsApp, Telegram, etc.)
-- Skills installation
-
-```bash
-sudo -u moltbot -i moltbot onboard
-```
-
-### 3. Environment Variables
-
-Copy the template and configure your API keys:
-
-```bash
-sudo -u moltbot cp /home/moltbot/.config/moltbot/moltbot.env.template /home/moltbot/.config/moltbot/.env
-sudo -u moltbot nano /home/moltbot/.config/moltbot/.env
-```
-
-Key settings:
-- **AI Provider** (choose one or more):
-  - `ANTHROPIC_API_KEY` - Anthropic Claude API key (recommended for Claude Opus 4.5)
-  - `OPENAI_API_KEY` - OpenAI API key (GPT models)
-  - `GEMINI_API_KEY` - Google Gemini API key
-- `MOLTBOT_PORT` - Gateway port (default: 18789)
-
-## Service Management
-
-```bash
-# Start the service
-sudo systemctl start moltbot-gateway
-
-# Stop the service
-sudo systemctl stop moltbot-gateway
-
-# Restart the service
 sudo systemctl restart moltbot-gateway
+```
 
-# Check status
-sudo systemctl status moltbot-gateway
-
-# View logs
+### View Logs
+```bash
 sudo journalctl -u moltbot-gateway -f
-
-# Enable auto-start on boot
-sudo systemctl enable moltbot-gateway
 ```
 
-## Accessing the Gateway
-
-Once running, access the Gateway UI at:
-
-```
-http://<your-vm-ip>:18789
-```
-
-### Gateway Token
-
-The Gateway UI requires an authentication token. The onboarding wizard (`moltbot onboard`) generates this token automatically and stores it in the OpenClaw config file.
-
-To retrieve the token:
-
-```bash
-sudo -u moltbot -i cat /home/moltbot/.moltbot/moltbot.json | jq -r '.gateway.auth.token'
-```
-
-Then open the Gateway UI with the token as a query parameter:
-
-```
-http://<your-vm-ip>:18789?token=YOUR_TOKEN
-```
-
-Or paste the token into the **Overview > Gateway Access** panel in the dashboard.
-
-For full setup instructions including firewall configuration, secure remote access, and troubleshooting, see the [Gateway UI Setup Guide](docs/GATEWAY_UI.md).
-
-For secure remote access, consider using [Tailscale Serve/Funnel](https://docs.openclaw.ai/gateway/tailscale).
-
-## Security Recommendations
-
-1. **Use a dedicated user**: The install script creates a `moltbot` user with limited privileges
-
-2. **Configure DM policies**: Use pairing mode (default) to require approval for new contacts
-   ```bash
-   sudo -u moltbot -i moltbot doctor
-   ```
-
-3. **Don't run as root**: Never run moltbot with elevated privileges
-
-4. **Use Tailscale**: For remote access, use Tailscale instead of exposing ports directly
-
-5. **Review skills**: Only install skills from trusted sources
-
-6. **Isolate the VM**: Run moltbot on a dedicated VM that doesn't contain sensitive data
-
-## Public or Private Repository?
-
-This repository is safe to make **public**. It contains only generic deployment scripts, systemd configuration, and documentation — no secrets, credentials, or server-specific details. API keys and SSH credentials are loaded from `.env` files (excluded by `.gitignore`) or GitHub Actions encrypted secrets, never from committed files.
-
-That said, consider the trade-offs before deciding:
-
-**Reasons to keep it public:**
-
-- **No secrets in the repo.** All credentials (API keys, SSH keys, hostnames) live in `.env` files or GitHub Actions secrets, not in version-controlled code. The `.env.template` contains only empty placeholders.
-- **Community benefit.** Others deploying OpenClaw can reuse and improve these scripts. Public visibility also invites bug reports, security audits, and contributions.
-- **Security through obscurity is not a defence.** The deployment patterns here (systemd hardening, SSH-based CI/CD, dedicated service user) are standard. Hiding them does not make your server safer; properly configuring them does.
-
-**Reasons to keep it private:**
-
-- **Reduces reconnaissance surface.** A public repo reveals your deployment architecture: CI/CD tooling, systemd sandbox boundaries, sudoers policy, default ports, and directory paths. An attacker who knows you run this stack can tailor their approach, even though no single detail is a vulnerability on its own.
-- **Operational privacy.** If you prefer not to publicly associate your GitHub account with a specific service running on your infrastructure, a private repo avoids that link.
-- **Fork-specific customisations.** If you add server-specific configuration (IP ranges, internal hostnames, custom firewall rules) to your fork, those details should not be public. A private repo prevents accidental exposure.
-
-**Recommendation:** If you use this repo as-is (without adding server-specific details), public is fine. If you fork it and customise it with details specific to your infrastructure, make the fork private or keep those changes in `.env` files and gitignored overlays.
-
-## Low-Memory VPS
-
-The minimum RAM for running OpenClaw is 2 GB (see [official system requirements](https://docs.openclaw.ai/help/faq)). Systems with 1 GB RAM do not have enough memory for the Node.js runtime, V8 heap, and channel connections combined — the OOM killer will terminate the gateway under normal operation.
-
-The installer automatically tunes resource limits based on detected RAM:
-
-| Setting | 2 GB RAM | 4 GB+ RAM |
-|---------|----------|-----------|
-| `MemoryMax` | 1536M | 2G |
-| `--max-old-space-size` | 1024 MB | 1536 MB |
-
-### Adding swap space (recommended for 2 GB RAM)
-
-Creating a swap file prevents the OOM killer from terminating moltbot during memory spikes:
-
-```bash
-# Create a 2 GB swap file
-sudo fallocate -l 2G /swapfile
-sudo chmod 600 /swapfile
-sudo mkswap /swapfile
-sudo swapon /swapfile
-
-# Make it permanent
-echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
-
-# Reduce swappiness so swap is only used under pressure
-echo 'vm.swappiness=10' | sudo tee -a /etc/sysctl.conf
-sudo sysctl -p
-```
-
-### Reducing channel overhead
-
-Each messaging channel (WhatsApp, Telegram, Discord, Slack) maintains a persistent connection that consumes memory. On a 2 GB VPS, enable only the channels you need in your `.env` file.
-
-## Troubleshooting
-
-### Service won't start
-
-Check the logs:
-```bash
-sudo journalctl -u moltbot-gateway -n 50
-```
-
-### Node.js version issues
-
-Verify Node.js is v22+:
-```bash
-sudo -u moltbot -i node -v
-```
-
-### Systemd service not found
-
-Reload systemd:
-```bash
-sudo systemctl daemon-reload
-```
-
-### Run diagnostics
-
+### Run Diagnostics
 ```bash
 sudo -u moltbot -i moltbot doctor
 ```
 
-## Updating OpenClaw
-
-Re-run the deployment script. It's idempotent — it will update the package, regenerate the systemd service, and restart:
-
+### Update OpenClaw
 ```bash
 sudo ./deploy/deploy.sh
 ```
 
-## Uninstalling
+For more, see **[Service Management](docs/SERVICE_MANAGEMENT.md)**.
 
+## Troubleshooting
+
+**Service won't start?**
 ```bash
-sudo ./deploy/uninstall.sh
+sudo journalctl -u moltbot-gateway -n 50
 ```
+
+**Out of memory?**
+See **[Low-Memory VPS](docs/LOW_MEMORY_VPS.md)** for swap setup.
+
+**Gateway unreachable?**
+See **[Troubleshooting Guide](docs/TROUBLESHOOTING.md)**.
+
+## Repository Visibility
+
+This repository is safe to make **public** — it contains no secrets, only generic deployment scripts and documentation. API keys are loaded from `.env` files (excluded by `.gitignore`) or GitHub Actions encrypted secrets.
+
+See **[Public vs. Private](docs/PUBLIC_VS_PRIVATE.md)** for details.
+
+## Contributing
+
+We welcome contributions! See **[Contributing Guidelines](CONTRIBUTING.md)** for:
+- Conventional commit format
+- Pull request process
+- Code review standards
+
+## Release Process
+
+This repository uses **semantic versioning** (0.1.0, 0.2.0, etc.). See **[Releasing Guide](RELEASING.md)** for:
+- How releases are automated
+- Version bumping rules
+- Deployment tracking
 
 ## Resources
 
-- [OpenClaw Documentation](https://docs.openclaw.ai)
-- [Getting Started Guide](https://docs.openclaw.ai/start/getting-started)
-- [Security Guide](https://docs.openclaw.ai/gateway/security)
-- [Channels Configuration](https://docs.openclaw.ai/channels)
-- [Skills Platform](https://docs.openclaw.ai/tools/skills)
+- **[OpenClaw Official Docs](https://docs.openclaw.ai)** — Complete guide to OpenClaw
+- **[OpenClaw GitHub](https://github.com/openclaw/openclaw)** — Source code and issues
+- **[Awesome Moltbot Skills](https://github.com/VoltAgent/awesome-moltbot-skills)** — 700+ community skills
+- **[Deployment Examples](https://docs.openclaw.ai)** — Installation on different platforms
 
 ## License
 
 MIT License - See [LICENSE](LICENSE) file
+
+---
+
+**Questions?** Start with the **[Quick Start Guide](docs/QUICK_START.md)** or check the **[Troubleshooting Guide](docs/TROUBLESHOOTING.md)**.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,228 @@
+# Configuration Guide
+
+Configure OpenClaw's AI provider, environment variables, and fallback behavior.
+
+## AI Providers
+
+OpenClaw is **model-agnostic** and supports multiple AI providers. Choose one or more for redundancy.
+
+| Provider | Recommended For | Setup | API Key |
+|----------|----------------|-------|---------|
+| **Anthropic** | Production (Claude Opus 4.5) | ✓ Automatic | [console.anthropic.com](https://console.anthropic.com/) |
+| **OpenAI** | Alternative (GPT-4, GPT-3.5) | ✓ Automatic | [platform.openai.com](https://platform.openai.com/api-keys) |
+| **Google Gemini** | Alternative (Gemini Pro, Ultra) | ✓ Automatic | [aistudio.google.com](https://aistudio.google.com/apikey) |
+
+Unlike ChatGPT's usage limits, you control your own API keys and rate limits.
+
+## Automatic Failover
+
+The deployment automatically configures **model fallbacks** based on your available API keys:
+
+1. **Primary**: Anthropic Claude Opus 4.5 (if `ANTHROPIC_API_KEY` is set)
+2. **Fallback 1**: OpenAI GPT-4 (if `OPENAI_API_KEY` is set)
+3. **Fallback 2**: Google Gemini Pro (if `GEMINI_API_KEY` is set)
+
+If the primary model fails (rate limits, API errors), OpenClaw automatically switches to the next available fallback. This ensures **continuous operation** even during API outages.
+
+### Customize Fallbacks
+
+Edit the fallback configuration:
+
+```bash
+sudo -u moltbot nano /home/moltbot/.config/moltbot/moltbot.fallbacks.json
+```
+
+Then apply changes:
+
+```bash
+sudo /opt/moltbot-deployment/deploy/configure-fallbacks.sh
+```
+
+The fallbacks configuration file controls:
+- Provider priority order
+- Model selection per provider
+- Timeout and retry behavior
+
+For detailed fallback configuration options, see the template at `deploy/moltbot.fallbacks.json`.
+
+## Environment Variables
+
+Copy the template and configure your settings:
+
+```bash
+sudo -u moltbot cp /home/moltbot/.config/moltbot/moltbot.env.template /home/moltbot/.config/moltbot/.env
+sudo -u moltbot nano /home/moltbot/.config/moltbot/.env
+```
+
+### AI Provider Keys
+
+```bash
+# Anthropic (recommended)
+ANTHROPIC_API_KEY=sk-ant-...
+
+# OpenAI (alternative)
+OPENAI_API_KEY=sk-...
+
+# Google Gemini (alternative)
+GEMINI_API_KEY=AIzaSy...
+```
+
+At least one API key is required. Multiple keys enable automatic failover.
+
+### Gateway Configuration
+
+```bash
+# Gateway web interface port (default: 18789)
+MOLTBOT_PORT=18789
+
+# Trusted proxies (if using reverse proxy like nginx or Tailscale)
+GATEWAY_TRUSTED_PROXIES=127.0.0.1
+# For Tailscale CGNAT range:
+GATEWAY_TRUSTED_PROXIES=100.64.0.0/10
+```
+
+### DM Policy (Security)
+
+```bash
+# pairing (default) — Requires approval code for new contacts
+# open — Accepts all new conversations (not recommended for production)
+DM_POLICY=pairing
+```
+
+### Resource Tuning
+
+The deploy script automatically sets these based on your RAM, but you can override:
+
+```bash
+# Memory limit for the service (e.g., 1536M for 2GB RAM, 2G for 4GB+ RAM)
+MEMORY_MAX=1536M
+
+# Node.js heap size (e.g., 1024 for 2GB RAM, 1536 for 4GB+ RAM)
+NODE_MAX_OLD_SPACE_SIZE=1024
+```
+
+### Channel Configuration
+
+Disable specific channels to reduce memory usage (each maintains a persistent connection):
+
+```bash
+# Set these to 0 or remove them to disable channels
+TELEGRAM_BOT_TOKEN=...      # Enable Telegram
+WHATSAPP_WEBHOOK_URL=...    # Enable WhatsApp
+DISCORD_TOKEN=...           # Enable Discord
+SLACK_BOT_TOKEN=...         # Enable Slack
+```
+
+For complete channel setup, see the [official channel configuration guide](https://docs.openclaw.ai/channels).
+
+## Onboarding Wizard
+
+The easiest way to configure OpenClaw:
+
+```bash
+sudo -u moltbot -i moltbot onboard
+```
+
+This interactive wizard guides you through:
+1. **LLM Provider**: Choose Anthropic, OpenAI, or Google Gemini
+2. **Workspace**: Set your workspace name and description
+3. **Channels**: Connect WhatsApp, Telegram, Discord, Slack, etc.
+4. **Skills**: Browse and install community skills from MoltHub
+
+The wizard automatically:
+- Generates the auth token for the Gateway UI
+- Creates your `.env` file with your API keys
+- Configures the systemd service
+- Sets up fallback providers if you have multiple keys
+
+## Manual Configuration (Without Onboarding)
+
+If you prefer to configure manually:
+
+```bash
+# 1. Copy the env template
+sudo -u moltbot cp /home/moltbot/.config/moltbot/moltbot.env.template /home/moltbot/.config/moltbot/.env
+
+# 2. Edit with your API keys
+sudo -u moltbot nano /home/moltbot/.config/moltbot/.env
+
+# 3. Set up fallbacks
+sudo /opt/moltbot-deployment/deploy/configure-fallbacks.sh
+
+# 4. Generate an auth token (if not already done)
+sudo -u moltbot -i moltbot config set gateway.auth.token "$(openssl rand -hex 32)"
+
+# 5. Restart the service
+sudo systemctl restart moltbot-gateway
+```
+
+## Changing Configuration
+
+After modifying `.env`:
+
+```bash
+# Restart the service to apply changes
+sudo systemctl restart moltbot-gateway
+
+# View logs to confirm it started
+sudo journalctl -u moltbot-gateway -f
+```
+
+To change configuration programmatically:
+
+```bash
+# Set a value
+sudo -u moltbot -i moltbot config set gateway.port 18789
+
+# View current config
+sudo -u moltbot -i cat /home/moltbot/.moltbot/moltbot.json | jq .
+```
+
+## Reverse Proxy Configuration
+
+If you expose OpenClaw through a reverse proxy (nginx, Tailscale, Cloudflare):
+
+### Set Trusted Proxies
+
+```bash
+# In /home/moltbot/.config/moltbot/.env
+GATEWAY_TRUSTED_PROXIES=127.0.0.1        # Local proxy
+GATEWAY_TRUSTED_PROXIES=100.64.0.0/10    # Tailscale CGNAT
+```
+
+The deploy script converts this to `gateway.trustedProxies` in the JSON config.
+
+Or set directly:
+
+```bash
+sudo -u moltbot -i moltbot config set gateway.trustedProxies '["127.0.0.1"]'
+```
+
+This ensures the gateway reads the real client IP from `X-Forwarded-For` headers instead of the proxy's IP.
+
+## Diagnostics
+
+Run the doctor command to check your configuration:
+
+```bash
+sudo -u moltbot -i moltbot doctor
+```
+
+This verifies:
+- All configured API keys are valid
+- Required environment variables are set
+- Service permissions are correct
+- Channels are properly configured
+
+Use `--repair` to fix common issues automatically:
+
+```bash
+sudo -u moltbot -i moltbot doctor --repair
+```
+
+## Related Documentation
+
+- [Quick Start](./QUICK_START.md) — Get up and running
+- [Service Management](./SERVICE_MANAGEMENT.md) — Start, stop, and monitor the service
+- [Security Guide](./SECURITY.md) — Hardening and security best practices
+- [Official Configuration Reference](https://docs.openclaw.ai/install/configuration) — Complete configuration documentation

--- a/docs/GITHUB_ACTIONS_DEPLOYMENT.md
+++ b/docs/GITHUB_ACTIONS_DEPLOYMENT.md
@@ -1,0 +1,148 @@
+# GitHub Actions CI/CD Deployment
+
+Automatically deploy OpenClaw to your VPS using GitHub Actions workflows.
+
+## One-Time Server Setup
+
+Before setting up CI/CD, prepare your VPS for automated deployments.
+
+### 1. Run Setup Script on VPS
+
+SSH into your VPS and run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Joe-Heffer/moltbot/main/deploy/setup-server.sh -o setup-server.sh
+chmod +x setup-server.sh
+sudo ./setup-server.sh
+```
+
+This creates a `deploy` user with limited sudo privileges for running deployments.
+
+### 2. Generate SSH Key Pair (on your local machine)
+
+```bash
+ssh-keygen -t ed25519 -C "github-actions-moltbot" -f ~/.ssh/moltbot-deploy
+```
+
+### 3. Add Public Key to VPS
+
+```bash
+ssh-copy-id -i ~/.ssh/moltbot-deploy.pub deploy@your-server-ip
+```
+
+### 4. Add GitHub Repository Secrets
+
+Go to your repository settings at `Settings > Secrets and variables > Actions` and add:
+
+| Secret | Value |
+|--------|-------|
+| `VPS_HOST` | Your VPS IP address |
+| `VPS_USERNAME` | `deploy` |
+| `VPS_SSH_KEY` | Contents of `~/.ssh/moltbot-deploy` (private key file) |
+| `VPS_PORT` | `22` (or your custom SSH port) |
+
+## Deployment Triggers
+
+The workflow runs automatically when:
+- Changes are pushed to the `main` branch in the `deploy/` directory
+- Manually triggered via GitHub Actions UI
+
+## Manual Deployment
+
+1. Go to **Actions** > **Deploy to VPS**
+2. Click **Run workflow**
+3. Choose an action:
+   - `deploy` — Install or update OpenClaw, regenerate all configuration
+   - `restart` — Restart the moltbot-gateway service
+
+## Workflow Features
+
+### Deployment Tracking
+Each deploy is recorded in GitHub Environments. View deployment history at:
+`Settings > Environments > production`
+
+Shows:
+- Deployment history and status
+- Associated commits
+- Previous deployed version (for rollback reference)
+
+### Concurrency Control
+Only one deployment runs at a time. Additional triggers queue instead of overlapping, preventing race conditions.
+
+### Health Checks
+After deployment, the workflow verifies:
+- The `moltbot-gateway` service is running
+- Port 18789 is listening and responding
+
+### Zero-Downtime Updates
+The service is only restarted after the update is confirmed successful.
+
+### Version Tracking
+Each deployment captures the git version and stores it on the VPS at `/opt/moltbot-version` for tracking which release is currently deployed.
+
+## Workflow File
+
+The workflow is defined at `.github/workflows/deploy.yml`. It runs:
+
+```bash
+git fetch origin
+git checkout <branch>
+sudo ./deploy/deploy.sh    # Idempotent deployment script
+```
+
+Refer to the [Deployment Details](./QUICK_START.md) for what `deploy.sh` does.
+
+## Troubleshooting
+
+### "Permission denied (publickey)" Error
+- Verify the public key is on the VPS: `cat ~/.ssh/authorized_keys | grep moltbot`
+- Check that the SSH key secret in GitHub matches your private key
+
+### Deployment Times Out
+- Check VPS network connectivity: `ssh -i ~/.ssh/moltbot-deploy deploy@your-server-ip`
+- Verify firewall allows SSH on port 22 (or your custom port)
+
+### Service Doesn't Restart After Deploy
+- SSH to VPS and check service status: `sudo systemctl status moltbot-gateway`
+- View logs: `sudo journalctl -u moltbot-gateway -n 50`
+
+## Monitoring Deployments
+
+Watch the workflow run in real time:
+
+1. Go to **Actions**
+2. Select **Deploy to VPS**
+3. Click the running workflow to see live logs
+4. Check the **Environments** section for deployment history
+
+## Rollback
+
+To rollback to a previous version:
+
+1. Find the previous version at `Settings > Environments > production`
+2. Check which commit was deployed
+3. Either:
+   - Revert the commit: `git revert <commit-hash>` and push to main
+   - Manually checkout a previous commit and push: `git checkout <commit-hash>` and push
+4. Trigger the deploy workflow to apply the older version
+
+Or manually on the VPS:
+
+```bash
+# View current version
+cat /opt/moltbot-version
+
+# Reinstall a specific version
+sudo npm install -g moltbot@0.2.0
+sudo ./deploy/deploy.sh
+```
+
+## Advanced: Custom Deployment Branch
+
+By default, the workflow deploys from the `main` branch. To deploy from a different branch, edit `.github/workflows/deploy.yml` and change:
+
+```yaml
+if: github.ref == 'refs/heads/main'
+```
+
+To your desired branch name. Then commit and push the change.

--- a/docs/LOW_MEMORY_VPS.md
+++ b/docs/LOW_MEMORY_VPS.md
@@ -1,0 +1,318 @@
+# Low-Memory VPS Setup
+
+Guide for running OpenClaw on VPS with limited RAM (2–4 GB).
+
+## System Requirements
+
+**Minimum**: 2 GB RAM (see [official system requirements](https://docs.openclaw.ai/help/faq))
+
+**Recommended**: 4 GB RAM for comfortable headroom
+
+**Not supported**: 1 GB RAM — OOM killer will terminate the service under normal operation.
+
+## Automatic Resource Tuning
+
+The deployment script automatically detects available RAM and configures limits:
+
+| RAM | MemoryMax | Node.js Heap | Swap Needed? |
+|-----|-----------|-------------|---|
+| 2 GB | 1536M | 1024 MB | Yes (recommended) |
+| 4 GB+ | 2G | 1536 MB | No (optional) |
+
+These limits prevent memory from consuming the entire system and allow proper functioning of other OS services.
+
+## Adding Swap Space (Recommended for 2 GB RAM)
+
+Swap prevents OOM killer from terminating OpenClaw during memory spikes.
+
+### Create a 2 GB Swap File
+
+```bash
+# Create the swap file
+sudo fallocate -l 2G /swapfile
+
+# Set permissions
+sudo chmod 600 /swapfile
+
+# Format as swap
+sudo mkswap /swapfile
+
+# Enable swap
+sudo swapon /swapfile
+```
+
+### Make Swap Permanent
+
+```bash
+# Add to fstab so it persists across reboots
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+```
+
+Verify:
+
+```bash
+sudo swapon --show
+```
+
+### Optimize Swap Behavior
+
+By default, Linux uses swap aggressively. Reduce this to only use swap under pressure:
+
+```bash
+# Set swappiness to 10 (use swap only when necessary)
+echo 'vm.swappiness=10' | sudo tee -a /etc/sysctl.conf
+
+# Apply immediately
+sudo sysctl -p
+```
+
+Verify:
+
+```bash
+cat /proc/sys/vm/swappiness
+# Should output: 10
+```
+
+### Monitor Swap Usage
+
+```bash
+# Check current swap usage
+free -h
+
+# Watch in real time
+watch -n 1 'free -h'
+```
+
+Example output:
+
+```
+               total       used       free     shared  buff/cache available
+Mem:           1.9G       1.2G       300M        20M       400M       600M
+Swap:          2.0G       150M       1.8G
+```
+
+If swap usage is consistently high (>50%), consider:
+- Disabling unused messaging channels
+- Upgrading to 4+ GB RAM
+- Running fewer concurrent skills
+
+## Reducing Memory Overhead
+
+Each messaging channel (Telegram, WhatsApp, Discord, Slack) maintains a persistent connection that consumes ~50-100 MB of RAM.
+
+### Disable Unused Channels
+
+Edit your environment configuration:
+
+```bash
+sudo -u moltbot nano /home/moltbot/.config/moltbot/.env
+```
+
+Comment out or remove the tokens for channels you don't use:
+
+```bash
+# Keep only the channels you need
+TELEGRAM_BOT_TOKEN=...         # Keep this
+# WHATSAPP_WEBHOOK_URL=...     # Disable (comment out)
+# DISCORD_TOKEN=...             # Disable (comment out)
+SLACK_BOT_TOKEN=...            # Keep this
+```
+
+Restart the service:
+
+```bash
+sudo systemctl restart moltbot-gateway
+```
+
+### Monitor Channel Memory Usage
+
+Check memory consumption before and after disabling channels:
+
+```bash
+# Before disabling
+sudo systemctl restart moltbot-gateway
+sleep 5
+ps aux | grep moltbot-gateway | grep -v grep
+
+# Disable a channel, restart
+sudo systemctl restart moltbot-gateway
+sleep 5
+ps aux | grep moltbot-gateway | grep -v grep
+```
+
+Compare the `%MEM` or `RES` columns (resident memory).
+
+## OOM Killer Prevention
+
+If you see "Out of memory" errors in logs, the OOM killer is terminating the service.
+
+### Check OOM Kill Log
+
+```bash
+sudo grep -i "out of memory" /var/log/syslog
+# or
+sudo dmesg | grep -i "out of memory"
+```
+
+### Increase Memory Limit
+
+If you're consistently hitting OOM:
+
+1. **Add more swap** (see section above)
+2. **Disable channels** you're not actively using
+3. **Upgrade to 4+ GB RAM**
+4. **Reduce Node.js heap** (only if you know what you're doing):
+   ```bash
+   # Edit service override
+   sudo systemctl edit --full moltbot-gateway
+
+   # Find NODE_MAX_OLD_SPACE_SIZE and reduce it
+   # WARNING: Too low will crash the service
+   ```
+
+## Disk Space Considerations
+
+OpenClaw stores logs, cache, and state files in `/home/moltbot/`. Monitor disk usage:
+
+```bash
+# Check disk space
+df -h /home/moltbot
+
+# Check directory size
+du -sh /home/moltbot/
+```
+
+If running low on disk:
+
+1. Clean old logs:
+   ```bash
+   sudo journalctl --disk-usage
+   sudo journalctl --vacuum-time=7d  # Keep only 7 days of logs
+   ```
+
+2. Clear cache (safe to do while running):
+   ```bash
+   sudo -u moltbot rm -rf /home/moltbot/.cache/*
+   ```
+
+## Performance Tips for Low-Memory Systems
+
+### 1. Monitor Regularly
+
+```bash
+# Watch in real time
+watch -n 2 'free -h && echo "---" && ps aux | grep moltbot | grep -v grep'
+```
+
+### 2. Graceful Restarts
+
+Instead of abrupt restarts, allow the service to finish in-flight requests:
+
+```bash
+sudo systemctl reload moltbot-gateway
+```
+
+### 3. Tune Swap Aggressiveness
+
+If swap is being used too often:
+
+```bash
+# Reduce swappiness further (more aggressive)
+echo 'vm.swappiness=5' | sudo tee -a /etc/sysctl.conf
+sudo sysctl -p
+```
+
+If swappiness is too low and swap isn't being used:
+
+```bash
+# Increase swappiness (less aggressive)
+echo 'vm.swappiness=30' | sudo tee -a /etc/sysctl.conf
+sudo sysctl -p
+```
+
+### 4. Limit Concurrent Skills
+
+Some community skills are memory-heavy. Limit concurrent execution in your config:
+
+```bash
+# In /home/moltbot/.config/moltbot/.env
+SKILL_CONCURRENCY_LIMIT=2
+```
+
+## Deployment on 2 GB VPS
+
+If deploying to a fresh 2 GB VPS:
+
+1. **Run setup script** (as usual):
+   ```bash
+   sudo ./deploy/deploy.sh
+   ```
+
+2. **Add swap immediately** (before first run):
+   ```bash
+   sudo fallocate -l 2G /swapfile
+   sudo chmod 600 /swapfile
+   sudo mkswap /swapfile
+   sudo swapon /swapfile
+   echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+   ```
+
+3. **Disable unnecessary channels** during onboarding:
+   ```bash
+   sudo -u moltbot -i moltbot onboard
+   ```
+   Only enable channels you need.
+
+4. **Monitor after setup**:
+   ```bash
+   watch -n 2 'free -h'
+   ```
+
+## Troubleshooting
+
+### "Cannot allocate memory" errors
+
+```bash
+sudo journalctl -u moltbot-gateway -n 50 | grep -i memory
+```
+
+Solutions:
+- Add more swap space
+- Disable unused channels
+- Upgrade RAM
+- Check for memory leaks: `sudo -u moltbot -i moltbot doctor`
+
+### Service crashes shortly after restart
+
+1. Check available memory:
+   ```bash
+   free -h
+   ```
+
+2. View crash logs:
+   ```bash
+   sudo journalctl -u moltbot-gateway -n 100
+   ```
+
+3. Increase memory limits (if possible) or disable channels
+
+### High swap usage (>50%)
+
+This indicates insufficient RAM for your workload:
+
+```bash
+# Check what's using memory
+ps aux --sort=-%mem | head -10
+```
+
+Options:
+- Disable channels
+- Upgrade to 4+ GB RAM
+- Run fewer concurrent skills
+
+## Related Documentation
+
+- [Quick Start](./QUICK_START.md) — Initial setup
+- [Service Management](./SERVICE_MANAGEMENT.md) — Monitor and troubleshoot
+- [Configuration Guide](./CONFIGURATION.md) — Disable channels
+- [Official System Requirements](https://docs.openclaw.ai/help/faq)

--- a/docs/PUBLIC_VS_PRIVATE.md
+++ b/docs/PUBLIC_VS_PRIVATE.md
@@ -1,0 +1,211 @@
+# Public vs. Private Repository
+
+Should you make your deployment repository public or keep it private? This guide outlines the trade-offs.
+
+## Quick Answer
+
+**If you use this repo as-is**: Public is fine.
+
+**If you customize it with server-specific details**: Keep it private or gitignore customizations.
+
+## Why This Repository is Safe to Make Public
+
+### No Secrets in the Repository
+
+- ✓ All credentials (API keys, SSH keys, hostnames) live in **`.env` files** (excluded by `.gitignore`)
+- ✓ GitHub Actions secrets are encrypted and not stored in the repo
+- ✓ The `.env.template` contains only empty placeholders
+- ✓ No hardcoded credentials anywhere in the code
+
+### Standard Security Practices
+
+The deployment patterns here are **standard Linux/systemd hardening**:
+- Non-root service user (`moltbot`)
+- Systemd sandbox constraints (`NoNewPrivileges`, `ProtectSystem`, `ProtectHome`)
+- SSH-based CI/CD with limited sudo privileges
+- Dedicated service port (18789)
+
+These practices are widely documented and don't become less secure by being public.
+
+### Community Benefit
+
+Making the repository public:
+- Allows others to reuse and improve the scripts
+- Invites bug reports and security audits
+- Enables community contributions
+- Helps the OpenClaw ecosystem
+
+### Security Through Implementation, Not Obscurity
+
+Hiding the deployment architecture does **not** make your server safer. A properly configured server is secure regardless of whether someone knows the pattern. Conversely, a misconfigured public repo cannot be made secure by making it private.
+
+## When to Keep It Private
+
+### Reasons to Keep It Private
+
+1. **Reduce reconnaissance surface**
+   - A public repo reveals your stack: CI/CD tooling, systemd setup, sudoers policy, port numbers
+   - An attacker can tailor reconnaissance knowing your patterns
+   - Note: This is "security through obscurity" — not a strong defense, but adds friction
+
+2. **Operational privacy**
+   - If you prefer not to publicly link your GitHub account to a running service
+   - If you want to keep your infrastructure setup confidential
+
+3. **Fork-specific customizations**
+   - If your fork includes server-specific details (IP ranges, internal hostnames, custom firewall rules)
+   - If you modify the scripts for your infrastructure
+
+### Example: When to Make a Fork Private
+
+```bash
+# KEEP PUBLIC: Generic deployment scripts
+# ✓ Git clone, run deploy.sh, done
+
+# MAKE PRIVATE: If you add to your fork
+# ✗ IP allowlists hardcoded in scripts
+# ✗ Internal hostname/FQDN references
+# ✗ Custom firewall rules specific to your network
+# ✗ Server-specific directory paths
+# ✗ Credentials in gitignored files but occasionally leaked
+```
+
+## Recommendations by Use Case
+
+### Individual Deployment (Your Own VPS)
+**Recommendation: Public**
+
+You're using the repo as-is without modifications. Making it public:
+- Helps others deploying OpenClaw
+- Allows community to spot issues
+- Adds no security risk since no secrets are stored
+
+### Organization/Team Deployment
+**Recommendation: Private (or public with gitignored customizations)**
+
+If your fork includes:
+- Server names, IP ranges, or internal hostnames
+- Custom monitoring/alerting setup
+- Org-specific environment variables
+
+Keep the fork private and manage customizations in:
+- `.env` files (already gitignored)
+- Separate configuration branches
+- Environment-specific overlays
+
+### Open-Source Project
+**Recommendation: Public**
+
+If you're publishing a deployment project for the community:
+- Public repo is expected and beneficial
+- Ensure no secrets in code (use `.env` and `.gitignore`)
+- Document security practices in README and SECURITY.md
+
+## Protecting Sensitive Information
+
+Regardless of public/private status, follow these practices:
+
+### 1. Use `.gitignore` for Secrets
+```bash
+# Already excluded:
+.env
+.env.local
+.env.*.local
+node_modules/
+.DS_Store
+```
+
+Never commit:
+- API keys or tokens
+- SSH private keys
+- Credentials or passwords
+- Personal information
+
+### 2. Code Review Before Push
+```bash
+git diff origin/main..HEAD
+```
+
+Ensure no secrets are in staging before pushing.
+
+### 3. Check Git History
+```bash
+# Search for common secret patterns
+git log -p --all -S 'sk-ant-' -- '*.env'
+git log -p --all -S 'ANTHROPIC_API_KEY' -- '*.env'
+```
+
+### 4. Credential Scanning Tools
+Use pre-commit hooks to scan before commits:
+
+```bash
+# Install git-secrets (macOS/Linux)
+brew install git-secrets
+git secrets --install
+git secrets --register-aws
+```
+
+Or use GitHub's native secret scanning (public repos only).
+
+## GitHub Secret Scanning
+
+**Public repositories only**: GitHub automatically scans for leaked credentials.
+
+If you accidentally commit a secret to a public repo:
+1. GitHub will alert you
+2. The credential is likely compromised — rotate it immediately
+3. Remove the secret and force-push (carefully):
+   ```bash
+   git filter-branch --tree-filter 'rm -rf .env' HEAD
+   git push --force-with-lease
+   ```
+
+## Making a Private Repo Public
+
+If you're currently private and want to go public:
+
+1. **Audit the entire history** for secrets:
+   ```bash
+   # Search for common patterns
+   git log -p --all -S 'ANTHROPIC_API_KEY'
+   git log -p --all -S 'sk-ant-'
+   git log -p --all -S 'sk-'  # OpenAI keys
+   ```
+
+2. **Clean secrets if found**:
+   - If a secret was committed, you must rotate it
+   - Use `git filter-branch` or `git-filter-repo` to rewrite history
+   - Force-push with team coordination
+
+3. **Document security practices** in SECURITY.md
+
+4. **Enable GitHub Secret Scanning** (public repos automatically get this)
+
+## Making a Public Repo Private
+
+If you're currently public and want to go private:
+
+1. Change visibility in `Settings > General > Danger Zone`
+2. No cleanup needed (private repos don't use secret scanning)
+3. Update any external links or references
+
+## Trade-Offs Summary
+
+| Aspect | Public | Private |
+|--------|--------|---------|
+| **Community benefit** | High | Low |
+| **Security risk** | Low (if no secrets) | None |
+| **Obscurity** | None | Adds friction |
+| **Maintenance** | Easier (community PRs) | More work |
+| **Visibility** | Everyone can see | Only team can see |
+| **Secret safety** | Must be careful | More forgiving but still important |
+
+## Related Documentation
+
+- [Security Hardening Guide](./SECURITY.md) — Best practices for production
+- [Quick Start](./QUICK_START.md) — Getting started
+- [Contributing Guidelines](../CONTRIBUTING.md) — How to contribute
+
+## Questions?
+
+For security concerns, see the [Security Guide](./SECURITY.md) or contact the OpenClaw maintainers on [GitHub Discussions](https://github.com/openclaw/openclaw/discussions).

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,0 +1,109 @@
+# Quick Start
+
+Get OpenClaw running on a Linux VPS in minutes.
+
+## Prerequisites
+
+- **OS**: Ubuntu 24.04 LTS (also supports Debian, RHEL, Oracle Linux)
+- **RAM**: At least 2 GB (4 GB recommended; see [Low-Memory VPS](./LOW_MEMORY_VPS.md))
+- **Root/sudo access**
+- **API key**: From [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), or [Google Gemini](https://aistudio.google.com/apikey)
+
+## Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/Joe-Heffer/moltbot.git
+cd moltbot
+
+# Run the deployment script (idempotent — safe to run multiple times)
+sudo ./deploy/deploy.sh
+```
+
+The script will:
+- Install Node.js 22
+- Create a dedicated `moltbot` user
+- Install OpenClaw globally via npm
+- Set up the `moltbot-gateway` systemd service
+- Configure AI provider fallbacks
+
+## Configuration
+
+### Run Onboarding
+
+```bash
+sudo -u moltbot -i moltbot onboard
+```
+
+The wizard guides you through:
+- LLM provider selection (Anthropic, OpenAI, or Google Gemini)
+- Workspace setup
+- Channel connections (WhatsApp, Telegram, Discord, Slack, etc.)
+- Skills installation
+
+### Manual Environment Setup (Optional)
+
+If you prefer to configure manually instead of running onboarding:
+
+```bash
+# Copy the environment template
+sudo -u moltbot cp /home/moltbot/.config/moltbot/moltbot.env.template /home/moltbot/.config/moltbot/.env
+
+# Edit with your API keys
+sudo -u moltbot nano /home/moltbot/.config/moltbot/.env
+```
+
+Key settings:
+- `ANTHROPIC_API_KEY` — Anthropic Claude API key
+- `OPENAI_API_KEY` — OpenAI API key (optional)
+- `GEMINI_API_KEY` — Google Gemini API key (optional)
+- `MOLTBOT_PORT` — Gateway port (default: 18789)
+
+## Start the Service
+
+```bash
+sudo systemctl start moltbot-gateway
+sudo systemctl enable moltbot-gateway
+```
+
+## Access the Gateway UI
+
+Open your browser and visit:
+
+```
+http://<your-vm-ip>:18789
+```
+
+Replace `<your-vm-ip>` with your server's IP address.
+
+**Authentication**: The onboarding wizard generates an auth token automatically. Retrieve it with:
+
+```bash
+sudo -u moltbot -i cat /home/moltbot/.moltbot/moltbot.json | jq -r '.gateway.auth.token'
+```
+
+Use the token in the URL or paste it into the Gateway UI login screen.
+
+For details, see [Gateway UI Setup](./GATEWAY_UI.md).
+
+## What's Next?
+
+- **Connect channels**: Configure WhatsApp, Telegram, Discord, Slack, etc. (see [official channel docs](https://docs.openclaw.ai/channels))
+- **Install skills**: Explore the [Skills Marketplace](https://docs.openclaw.ai/tools/skills)
+- **Secure access**: Use [Tailscale](https://tailscale.com/) instead of exposing the port directly (see [Security Guide](./SECURITY.md))
+- **Monitor service**: View logs with `sudo journalctl -u moltbot-gateway -f`
+- **Run diagnostics**: Execute `sudo -u moltbot -i moltbot doctor`
+
+## Troubleshooting
+
+- **Service won't start**: Check logs with `sudo journalctl -u moltbot-gateway -n 50`
+- **Out of memory**: See [Low-Memory VPS](./LOW_MEMORY_VPS.md)
+- **Node.js issues**: Verify Node.js v22+ with `sudo -u moltbot -i node -v`
+- **More help**: See [Troubleshooting Guide](./TROUBLESHOOTING.md)
+
+## Next Steps
+
+- [Configuration Guide](./CONFIGURATION.md) — AI providers, fallbacks, and environment variables
+- [Deployment Options](./DEPLOYMENT.md) — Other platforms (local, Docker, NAS, etc.)
+- [GitHub Actions CI/CD](./GITHUB_ACTIONS_DEPLOYMENT.md) — Automated deployment and updates
+- [Service Management](./SERVICE_MANAGEMENT.md) — Start, stop, restart, and logs

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,114 +1,143 @@
 # OpenClaw Documentation
 
-Welcome to the OpenClaw documentation. This directory contains guides for use cases, deployment options, security, community applications, and cost information.
+Welcome to the OpenClaw deployment documentation. This directory contains guides for getting started, configuring, securing, and troubleshooting your deployment.
 
-## Official Documentation
+## Quick Navigation
 
-The primary source for OpenClaw/Moltbot documentation is:
-- **[OpenClaw Documentation](https://docs.openclaw.ai)** — Main documentation hub with index, architecture, installation, and configuration reference
+### 🚀 Getting Started
+- **[Quick Start](./QUICK_START.md)** — Deploy in 5-10 minutes
+- **[Deployment Options](./DEPLOYMENT.md)** — VPS, local, Docker, NAS, and more
 
-## Quick Links
+### ⚙️ Configuration & Setup
+- **[Configuration Guide](./CONFIGURATION.md)** — AI providers, environment variables, onboarding
+- **[Service Management](./SERVICE_MANAGEMENT.md)** — Start, stop, monitor the service
+- **[Gateway UI Setup](./GATEWAY_UI.md)** — Access the web interface
+- **[Telegram Setup](./TELEGRAM_SETUP.md)** — Connect Telegram bot
+- **[WhatsApp Legal & ToS](./WHATSAPP_LEGAL.md)** — Important considerations
 
-### Getting Started
-- **[Official Documentation](https://docs.openclaw.ai/start/getting-started)** - Complete getting started guide
-- **[Deployment Guide](./DEPLOYMENT.md)** - How to deploy OpenClaw across different platforms
+### 🔄 Operations & Automation
+- **[GitHub Actions CI/CD](./GITHUB_ACTIONS_DEPLOYMENT.md)** — Automated deployment and updates
+- **[Low-Memory VPS](./LOW_MEMORY_VPS.md)** — Optimize for 2–4 GB RAM systems
 
-### Understanding OpenClaw
-- **[Use Cases](./USE_CASES.md)** - Real-world applications and workflows
-  - Personal productivity (calendar, email, tasks)
-  - Developer and DevOps workflows
-  - Home automation and IoT
-  - Media and content management
-  - Finance and tracking
-  - Research and knowledge management
+### 🔒 Security & Hardening
+- **[Security Guide](./SECURITY.md)** — Hardening checklist and best practices
+- **[Public vs. Private Repo](./PUBLIC_VS_PRIVATE.md)** — Repository visibility considerations
 
-- **[Community Applications](./COMMUNITY_APPLICATIONS.md)** - Creative examples from the community
-  - Notable use cases and examples
-  - Skills ecosystem overview
+### 📚 Reference & Learning
+- **[Repository Structure](./REPOSITORY_STRUCTURE.md)** — Files, scripts, workflows
+- **[Troubleshooting](./TROUBLESHOOTING.md)** — Common issues and solutions
+- **[Use Cases](./USE_CASES.md)** — Real-world applications
+- **[Cost Expectations](./COST_EXPECTATIONS.md)** — Pricing and budget planning
+- **[Community Applications](./COMMUNITY_APPLICATIONS.md)** — Examples from the community
 
-### Running OpenClaw
-- **[Gateway UI Setup](./GATEWAY_UI.md)** - Access and configure the web interface
-- **[Deployment Options](./DEPLOYMENT.md)** - Choose the right setup for you
-  - Linux VPS (recommended for production)
-  - DigitalOcean 1-Click marketplace image
-  - Cloudflare Workers (serverless)
-  - Local machine (Mac, Linux, WSL2)
-  - NAS and embedded hardware
+## Recommended Reading Order
 
-- **[Security Guide](./SECURITY.md)** - Secure deployment and hardening checklist
-  - Risk assessment
-  - Security best practices
-  - Hardening recommendations
+**First time deploying?**
+1. [Quick Start](./QUICK_START.md) — Get it running
+2. [Configuration Guide](./CONFIGURATION.md) — Set up API keys
+3. [Security Guide](./SECURITY.md) — Harden your setup
 
-- **[Telegram Setup](./TELEGRAM_SETUP.md)** - Connect OpenClaw to Telegram via BotFather
-  - Creating a bot and obtaining a token
-  - Configuring the token on your server
-  - Security considerations
+**Need to automate?**
+1. [GitHub Actions CI/CD](./GITHUB_ACTIONS_DEPLOYMENT.md) — Set up GitHub Actions
+2. [Repository Structure](./REPOSITORY_STRUCTURE.md) — Understand the scripts
 
-- **[WhatsApp Legal & ToS](./WHATSAPP_LEGAL.md)** - WhatsApp Terms of Service considerations
-  - Unofficial automation risks and account bans
-  - Official Business API vs unofficial libraries
-  - 2025-2026 AI chatbot policy changes
-  - Platform comparison (Discord, Telegram, Slack, Signal)
+**Having issues?**
+1. [Troubleshooting](./TROUBLESHOOTING.md) — Find your problem
+2. [Low-Memory VPS](./LOW_MEMORY_VPS.md) — If out of memory
+3. [Service Management](./SERVICE_MANAGEMENT.md) — Monitor and debug
 
-- **[Troubleshooting](./TROUBLESHOOTING.md)** - Common issues and how to fix them
-  - Missing config crash loop
-  - Health check failures
-  - OOM kills and low-memory fixes
+## Official OpenClaw Documentation
 
-- **[Cost Expectations](./COST_EXPECTATIONS.md)** - Pricing and budget planning
+For OpenClaw-specific features (channels, skills, architecture), refer to the official documentation:
+- **[OpenClaw Documentation](https://docs.openclaw.ai)** — Main documentation hub
+- **[Channel Configuration](https://docs.openclaw.ai/channels)** — WhatsApp, Telegram, Discord, Slack, etc.
+- **[Skills Marketplace](https://docs.openclaw.ai/tools/skills)** — Discover and install skills
+- **[Architecture Overview](https://docs.openclaw.ai)** — System design and capabilities
 
-## Deployment Quick Start
-
-Choose your platform:
+## Deployment Quick Reference
 
 | Platform | Setup Time | Best For | Cost |
 |----------|-----------|---------|------|
-| **Linux VPS** | 10 min | Always-on, production | $4-24/mo |
-| **DigitalOcean 1-Click** | 5 min | Quick start, no config | $4-24/mo |
-| **Cloudflare Workers** | 15 min | Serverless, low-cost | ~$5/mo |
-| **Local Machine** | 5 min | Development, personal | Free |
+| **Linux VPS** | 5-10 min | Always-on, production | $4-24/mo |
+| **GitHub Actions** | 10 min | Automated updates | Free (with secrets) |
+| **DigitalOcean 1-Click** | 5 min | Quick start | $4-24/mo |
+| **Cloudflare Workers** | 15 min | Serverless | ~$5/mo |
+| **Local Machine** | 5 min | Development | Free |
 | **NAS/Raspberry Pi** | 20 min | Home automation | Varies |
 
-For detailed instructions, see [Deployment Guide](./DEPLOYMENT.md).
-
-## Community & Support
-
-- **[Awesome OpenClaw Skills](https://github.com/VoltAgent/awesome-moltbot-skills)** - 700+ community skills
-- **[Official GitHub](https://github.com/openclaw/openclaw)** - Source code and issues
-- **[Skills Marketplace](https://docs.openclaw.ai/tools/skills)** - Discover and install skills
-
-## Security First
-
-Before deploying, review the [Security Guide](./SECURITY.md) to understand risk vectors and hardening best practices.
-
-## Additional Resources
-
-- **Tutorials**
-  - [DigitalOcean quickstart](https://www.digitalocean.com/community/tutorials/moltbot-quickstart-guide)
-  - [Hostinger VPS installation](https://www.hostinger.com/support/how-to-install-moltbot-on-hostinger-vps/)
-  - [Mac Mini setup](https://beebom.com/how-to-set-up-clawdbot-moltbot-on-mac-mini/)
-
-- **Analysis & Commentary**
-  - [TechCrunch: Everything you need to know](https://techcrunch.com/2026/01/27/everything-you-need-to-know-about-viral-personal-ai-assistant-clawdbot-now-moltbot/)
-  - [DEV Community: Ultimate guide](https://dev.to/czmilo/moltbot-the-ultimate-personal-ai-assistant-guide-for-2026-d4e)
-  - [Cloudflare: Introducing Moltworker](https://blog.cloudflare.com/moltworker-self-hosted-ai-agent/)
+Choose your platform and follow the **[Quick Start](./QUICK_START.md)** or **[Deployment Options](./DEPLOYMENT.md)** guide.
 
 ## File Structure
 
 ```
 docs/
-├── README.md                      (this file - navigation hub)
-├── USE_CASES.md                   (use cases by category)
-├── DEPLOYMENT.md                  (deployment options)
-├── SECURITY.md                    (security hardening)
-├── COMMUNITY_APPLICATIONS.md      (community examples)
-├── GATEWAY_UI.md                  (gateway web interface setup)
-├── TELEGRAM_SETUP.md              (Telegram bot setup guide)
-├── WHATSAPP_LEGAL.md              (WhatsApp ToS and legal considerations)
-├── TROUBLESHOOTING.md             (common issues and fixes)
-├── COST_EXPECTATIONS.md           (pricing information)
-└── use-cases-and-deployment.md    (legacy combined file - deprecated)
+├── README.md                          (this file - navigation hub)
+├── QUICK_START.md                     (5-min deployment guide)
+├── CONFIGURATION.md                   (AI providers, env vars, onboarding)
+├── SERVICE_MANAGEMENT.md              (systemctl, monitoring, logs)
+├── GITHUB_ACTIONS_DEPLOYMENT.md       (CI/CD setup and automation)
+├── DEPLOYMENT.md                      (multi-platform deployment options)
+├── LOW_MEMORY_VPS.md                  (2-4 GB RAM optimization)
+├── GATEWAY_UI.md                      (web interface setup)
+├── TELEGRAM_SETUP.md                  (Telegram bot setup)
+├── WHATSAPP_LEGAL.md                  (WhatsApp ToS and risks)
+├── SECURITY.md                        (hardening checklist)
+├── PUBLIC_VS_PRIVATE.md               (repo visibility guide)
+├── REPOSITORY_STRUCTURE.md            (repo files and scripts)
+├── TROUBLESHOOTING.md                 (common issues)
+├── USE_CASES.md                       (real-world applications)
+├── COST_EXPECTATIONS.md               (pricing guide)
+└── COMMUNITY_APPLICATIONS.md          (community examples)
 ```
 
-For the canonical combined reference, see [use-cases-and-deployment.md](./use-cases-and-deployment.md).
+## Common Commands
+
+### Deploy to VPS
+```bash
+git clone https://github.com/Joe-Heffer/moltbot.git
+cd moltbot
+sudo ./deploy/deploy.sh
+```
+
+### Configure via Onboarding
+```bash
+sudo -u moltbot -i moltbot onboard
+```
+
+### Start the Service
+```bash
+sudo systemctl start moltbot-gateway
+sudo systemctl enable moltbot-gateway
+```
+
+### View Logs
+```bash
+sudo journalctl -u moltbot-gateway -f
+```
+
+### Update OpenClaw
+```bash
+cd moltbot
+git pull origin main
+sudo ./deploy/deploy.sh
+```
+
+## Need Help?
+
+- **Getting started?** → [Quick Start](./QUICK_START.md)
+- **Setting up GitHub Actions?** → [GitHub Actions CI/CD](./GITHUB_ACTIONS_DEPLOYMENT.md)
+- **Configuring API keys?** → [Configuration Guide](./CONFIGURATION.md)
+- **Service issues?** → [Service Management](./SERVICE_MANAGEMENT.md)
+- **Out of memory?** → [Low-Memory VPS](./LOW_MEMORY_VPS.md)
+- **Security concerns?** → [Security Guide](./SECURITY.md)
+- **Other problems?** → [Troubleshooting](./TROUBLESHOOTING.md)
+
+## Community & Support
+
+- **[OpenClaw GitHub Issues](https://github.com/openclaw/openclaw/issues)** — Report bugs and feature requests
+- **[OpenClaw Discussions](https://github.com/openclaw/openclaw/discussions)** — Ask questions and share ideas
+- **[Awesome Moltbot Skills](https://github.com/VoltAgent/awesome-moltbot-skills)** — 700+ community skills
+
+---
+
+**Ready to start?** Head to [Quick Start](./QUICK_START.md) or [Documentation Hub](../README.md) for an overview.

--- a/docs/REPOSITORY_STRUCTURE.md
+++ b/docs/REPOSITORY_STRUCTURE.md
@@ -1,0 +1,310 @@
+# Repository Structure
+
+Overview of files and directories in the OpenClaw deployment repository.
+
+## Directory Tree
+
+```
+moltbot/
+├── deploy/                         # Deployment scripts
+│   ├── deploy.sh                   # Main idempotent deployment script
+│   ├── uninstall.sh                # Removal script
+│   ├── setup-server.sh             # One-time CI/CD server preparation
+│   ├── configure-fallbacks.sh      # AI provider fallback configuration
+│   ├── lib.sh                      # Shared library (logging, validation)
+│   ├── moltbot-gateway.service     # Systemd service template
+│   ├── moltbot.env.template        # Environment variable template
+│   └── moltbot.fallbacks.json      # AI provider fallback configuration template
+│
+├── .github/
+│   └── workflows/
+│       ├── deploy.yml              # GitHub Actions: deploy to VPS
+│       ├── release.yml             # GitHub Actions: semantic versioning
+│       └── lint.yml                # GitHub Actions: code quality checks
+│
+├── docs/                           # Extended documentation
+│   ├── README.md                   # Documentation hub and navigation
+│   ├── QUICK_START.md              # Deployment quick start
+│   ├── CONFIGURATION.md            # AI providers, env vars, onboarding
+│   ├── SERVICE_MANAGEMENT.md       # systemctl commands, monitoring
+│   ├── GITHUB_ACTIONS_DEPLOYMENT.md # CI/CD setup and workflows
+│   ├── DEPLOYMENT.md               # Multi-platform deployment options
+│   ├── LOW_MEMORY_VPS.md           # Low-memory VPS optimization
+│   ├── REPOSITORY_STRUCTURE.md     # This file
+│   ├── PUBLIC_VS_PRIVATE.md        # Public/private repo considerations
+│   ├── GATEWAY_UI.md               # Gateway web interface setup
+│   ├── SECURITY.md                 # Security hardening checklist
+│   ├── TROUBLESHOOTING.md          # Common issues and fixes
+│   ├── USE_CASES.md                # Real-world applications
+│   ├── COST_EXPECTATIONS.md        # Pricing and budget planning
+│   ├── COMMUNITY_APPLICATIONS.md   # Community examples
+│   ├── TELEGRAM_SETUP.md           # Telegram bot setup
+│   └── WHATSAPP_LEGAL.md           # WhatsApp Terms of Service
+│
+├── README.md                       # Main project overview and quick start
+├── CONTRIBUTING.md                 # Contribution guidelines
+├── RELEASING.md                    # Release versioning and process
+├── CLAUDE.md                       # AI assistant context (this file)
+├── VERSION                         # Current semantic version (e.g., 0.1.0)
+├── LICENSE                         # MIT License
+└── .gitignore                      # Git ignore rules
+```
+
+## Core Files
+
+### Deployment Scripts (`deploy/`)
+
+#### `deploy.sh`
+**Primary deployment script — idempotent, safe to run multiple times.**
+
+Performs:
+1. Installs system dependencies (curl, git, gcc, Node.js)
+2. Installs Node.js 22 via NodeSource
+3. Creates dedicated `moltbot` system user
+4. Installs/updates moltbot via npm
+5. Generates systemd service from template
+6. Configures AI provider fallbacks
+7. Restarts service if already running; prints onboarding instructions on first install
+
+**Usage:**
+```bash
+sudo ./deploy/deploy.sh
+```
+
+**Idempotent**: Safe to run for both first-time installation and subsequent updates.
+
+#### `uninstall.sh`
+Completely removes OpenClaw from the system.
+
+**Usage:**
+```bash
+sudo ./deploy/uninstall.sh
+```
+
+Removes:
+- moltbot npm package
+- moltbot system user
+- systemd service
+- Configuration files
+
+#### `setup-server.sh`
+One-time VPS preparation for GitHub Actions CI/CD deployments.
+
+**Usage:**
+```bash
+sudo ./deploy/setup-server.sh
+```
+
+Creates:
+- `deploy` user with limited sudo privileges
+- SSH directory for deployment key
+- Sudoers entries for deployment commands
+
+Required before setting up GitHub Actions CI/CD.
+
+#### `configure-fallbacks.sh`
+Applies AI provider fallback configuration from `moltbot.fallbacks.json`.
+
+**Usage:**
+```bash
+sudo /opt/moltbot-deployment/deploy/configure-fallbacks.sh
+```
+
+Converts fallback JSON into gateway configuration.
+
+#### `lib.sh`
+Shared Bash library sourced by deployment scripts.
+
+Provides:
+- Logging functions (`log_info`, `log_success`, `log_warn`, `log_error`)
+- Validation functions (`require_root`, `validate_port`)
+- Memory detection and tuning (`detect_ram`, `calculate_memory_limits`)
+- Cross-distro support (Debian/Ubuntu, RHEL/CentOS)
+
+Not run directly; sourced by other scripts.
+
+#### `moltbot-gateway.service`
+Systemd service template for running OpenClaw as a background service.
+
+Features:
+- Runs as dedicated `moltbot` user (non-root)
+- Security hardening: `NoNewPrivileges`, `ProtectSystem=strict`, `ProtectHome=read-only`
+- Memory and CPU limits based on detected RAM
+- Automatic restart on failure
+- Service dependencies (after network is online)
+
+Deployed to `/etc/systemd/system/moltbot-gateway.service` by `deploy.sh`.
+
+#### `moltbot.env.template`
+Template for environment variables.
+
+Copy and configure:
+```bash
+sudo -u moltbot cp /home/moltbot/.config/moltbot/moltbot.env.template /home/moltbot/.config/moltbot/.env
+sudo -u moltbot nano /home/moltbot/.config/moltbot/.env
+```
+
+Includes settings for:
+- AI provider API keys (Anthropic, OpenAI, Gemini)
+- Gateway port and proxy configuration
+- Channel tokens (Telegram, Discord, Slack, etc.)
+- DM policy (pairing vs. open)
+- Resource limits (memory, Node.js heap)
+
+#### `moltbot.fallbacks.json`
+Template for AI provider fallback configuration.
+
+Defines:
+- Provider priority order
+- Model selection per provider
+- Timeout and retry behavior
+
+Customized and applied by `configure-fallbacks.sh`.
+
+## GitHub Actions Workflows (`.github/workflows/`)
+
+### `deploy.yml`
+Automated deployment to VPS via SSH.
+
+**Triggers:**
+- Push to `main` branch in `deploy/` directory
+- Manual trigger via GitHub Actions UI
+
+**Actions:**
+- `deploy` — Install or update, regenerate configuration
+- `restart` — Restart the gateway service
+
+**Features:**
+- Deployment tracking in GitHub Environments
+- Health checks post-deploy
+- Concurrency control (one deploy at a time)
+- Version tracking (`/opt/moltbot-version` on VPS)
+
+See [GitHub Actions Deployment Guide](./GITHUB_ACTIONS_DEPLOYMENT.md).
+
+### `release.yml`
+Automated semantic versioning and GitHub Releases.
+
+**Triggers:**
+- Manual workflow dispatch with version bump type (major, minor, patch)
+- Automatically analyzes commits since last release
+
+**Process:**
+1. Analyzes conventional commit messages (feat, fix, etc.)
+2. Determines version bump (major/minor/patch)
+3. Updates `VERSION` file
+4. Creates git tag
+5. Generates GitHub Release with commit history
+
+See [RELEASING.md](../RELEASING.md) for details.
+
+### `lint.yml`
+Code quality checks on every push and pull request.
+
+**Checks:**
+- `shellcheck` — Bash script linting
+- `actionlint` — GitHub Actions workflow validation
+- `yamllint` — YAML linting with 200-char line limit
+
+## Documentation Structure
+
+### Navigation Hub
+- **`docs/README.md`** — Quick links to all documentation, deployment quick start table, community resources
+
+### Getting Started
+- **`docs/QUICK_START.md`** — Minimal steps to deploy and configure
+- **`docs/DEPLOYMENT.md`** — Multi-platform deployment options
+
+### Operation & Management
+- **`docs/CONFIGURATION.md`** — AI providers, environment variables, onboarding
+- **`docs/SERVICE_MANAGEMENT.md`** — systemctl commands, monitoring, troubleshooting
+- **`docs/GITHUB_ACTIONS_DEPLOYMENT.md`** — CI/CD setup and workflows
+- **`docs/LOW_MEMORY_VPS.md`** — Optimization for limited RAM systems
+
+### Architecture & Planning
+- **`docs/REPOSITORY_STRUCTURE.md`** — This file
+- **`docs/DEPLOYMENT.md`** — Architecture overview for different platforms
+
+### Security & Hardening
+- **`docs/SECURITY.md`** — Hardening checklist and best practices
+- **`docs/PUBLIC_VS_PRIVATE.md`** — Repository visibility considerations
+
+### Setup Guides
+- **`docs/GATEWAY_UI.md`** — Web interface access and authentication
+- **`docs/TELEGRAM_SETUP.md`** — Telegram bot configuration
+- **`docs/WHATSAPP_LEGAL.md`** — WhatsApp Terms of Service and unofficial risks
+
+### Reference & Context
+- **`docs/USE_CASES.md`** — Real-world applications and workflows
+- **`docs/COST_EXPECTATIONS.md`** — Pricing and budget planning
+- **`docs/COMMUNITY_APPLICATIONS.md`** — Community examples and integrations
+- **`docs/TROUBLESHOOTING.md`** — Common issues and solutions
+
+### Root Documentation
+- **`README.md`** — Main project overview, quick start, key information
+- **`CONTRIBUTING.md`** — Contribution guidelines, conventional commit format
+- **`RELEASING.md`** — Semantic versioning and release process
+- **`CLAUDE.md`** — AI assistant context and development conventions
+- **`VERSION`** — Current semantic version (e.g., `0.1.0`)
+- **`LICENSE`** — MIT License
+
+## Key Concepts
+
+### Idempotent Deployment
+`deploy.sh` is designed to be run multiple times safely:
+- First run: installs everything
+- Subsequent runs: updates npm package, regenerates systemd service, restarts service
+
+This enables both:
+- Manual updates via `sudo ./deploy/deploy.sh`
+- Automated updates via GitHub Actions
+
+### Security Model
+- **Non-root execution**: OpenClaw runs as `moltbot` user, not root
+- **Systemd hardening**: `NoNewPrivileges`, `ProtectSystem`, `ProtectHome` prevent privilege escalation
+- **Memory/CPU limits**: Resource constraints prevent runaway processes
+- **Dedicated user**: Isolates OpenClaw from other system services
+
+### Configuration Management
+- **Environment variables**: Stored in `.env`, loaded by systemd service
+- **Fallback configuration**: JSON format, applied by `configure-fallbacks.sh`
+- **Systemd service template**: Generated from `moltbot-gateway.service` with substituted values
+
+### Supported Distributions
+- **Debian/Ubuntu** — Primary target (Ubuntu 24.04 LTS)
+- **RHEL/CentOS** — Community supported
+- **Oracle Linux** — Community supported
+
+Scripts detect and adapt to different package managers (apt, dnf, yum).
+
+## Development Conventions
+
+### Bash Scripts
+- Use `set -euo pipefail` for safety
+- Source `lib.sh` for logging and utilities
+- Support Debian/Ubuntu and RHEL families
+- Shellcheck-compliant
+
+### Commit Messages
+Follow [conventional commits](../CONTRIBUTING.md):
+- `feat:` → MINOR version bump
+- `fix:` → PATCH version bump
+- `docs:`, `chore:`, `ci:` → no version bump
+- `BREAKING CHANGE:` → MAJOR version bump
+
+### YAML/Workflow Files
+- Pin GitHub Actions to full commit SHAs with version comments
+- Keep lines under 200 characters
+- Use `actionlint` for validation
+
+### Documentation
+- Markdown in `docs/`, linked from `docs/README.md`
+- Keep top-level `README.md` focused and concise
+- Use cross-links to reduce redundancy
+
+## Related Documentation
+
+- [Quick Start](./QUICK_START.md) — Get up and running
+- [Contributing Guidelines](../CONTRIBUTING.md) — How to contribute
+- [Release Process](../RELEASING.md) — Versioning and releases
+- [AI Assistant Context](../CLAUDE.md) — Development conventions

--- a/docs/SERVICE_MANAGEMENT.md
+++ b/docs/SERVICE_MANAGEMENT.md
@@ -1,0 +1,315 @@
+# Service Management
+
+Start, stop, monitor, and troubleshoot the OpenClaw gateway service.
+
+## Service Commands
+
+### Start the Service
+
+```bash
+sudo systemctl start moltbot-gateway
+```
+
+### Stop the Service
+
+```bash
+sudo systemctl stop moltbot-gateway
+```
+
+### Restart the Service
+
+```bash
+sudo systemctl restart moltbot-gateway
+```
+
+After changing configuration files (`.env`, fallbacks), always restart:
+
+```bash
+# Edit config
+sudo -u moltbot nano /home/moltbot/.config/moltbot/.env
+
+# Restart to apply changes
+sudo systemctl restart moltbot-gateway
+```
+
+### Enable Auto-Start on Boot
+
+```bash
+sudo systemctl enable moltbot-gateway
+```
+
+Disable auto-start:
+
+```bash
+sudo systemctl disable moltbot-gateway
+```
+
+### Check Service Status
+
+```bash
+sudo systemctl status moltbot-gateway
+```
+
+Shows:
+- Current status (running, stopped, failed)
+- Process ID (PID)
+- Memory and CPU usage
+- Recent log output
+
+## Viewing Logs
+
+### Live Logs (Follow Mode)
+
+```bash
+sudo journalctl -u moltbot-gateway -f
+```
+
+Streams logs in real time. Press `Ctrl+C` to exit.
+
+### Recent Logs
+
+```bash
+# Last 50 lines
+sudo journalctl -u moltbot-gateway -n 50
+
+# Last 100 lines
+sudo journalctl -u moltbot-gateway -n 100
+```
+
+### Logs Since a Specific Time
+
+```bash
+# Last 10 minutes
+sudo journalctl -u moltbot-gateway --since "10 minutes ago"
+
+# Last 1 hour
+sudo journalctl -u moltbot-gateway --since "1 hour ago"
+
+# Since a specific date/time
+sudo journalctl -u moltbot-gateway --since "2025-02-01 10:00:00"
+```
+
+### Verbose Logs
+
+```bash
+# All log levels including debug
+sudo journalctl -u moltbot-gateway -p debug -n 50
+
+# Only errors
+sudo journalctl -u moltbot-gateway -p err -n 50
+```
+
+## Common Status Checks
+
+### Verify Service is Running
+
+```bash
+sudo systemctl is-active moltbot-gateway
+```
+
+Output: `active` or `inactive`
+
+### Check Gateway Port
+
+```bash
+# Is port 18789 listening?
+sudo netstat -tlnp | grep 18789
+# or
+sudo ss -tlnp | grep 18789
+```
+
+### Test Gateway Response
+
+```bash
+# Quick health check
+curl -s http://localhost:18789/health | jq .
+
+# Or without jq
+curl -s http://localhost:18789/health
+```
+
+### Monitor Resource Usage
+
+```bash
+# Real-time system monitor
+top -p $(pgrep -f 'moltbot-gateway')
+
+# Or use htop for better formatting
+htop -p $(pgrep -f 'moltbot-gateway')
+```
+
+## Troubleshooting
+
+### Service Won't Start
+
+Check the logs:
+
+```bash
+sudo journalctl -u moltbot-gateway -n 50
+```
+
+Common causes:
+- **Port already in use**: Check if another process is listening on 18789
+  ```bash
+  sudo lsof -i :18789
+  ```
+- **Permission denied**: Ensure the `moltbot` user owns config files:
+  ```bash
+  sudo chown -R moltbot:moltbot /home/moltbot/.config
+  ```
+- **Out of memory**: See [Low-Memory VPS](./LOW_MEMORY_VPS.md)
+- **Config file errors**: Validate JSON in `/home/moltbot/.config/moltbot/.env`
+
+### Service Crashes Repeatedly
+
+1. Check logs for the error:
+   ```bash
+   sudo journalctl -u moltbot-gateway -n 100
+   ```
+
+2. Run diagnostics:
+   ```bash
+   sudo -u moltbot -i moltbot doctor
+   ```
+
+3. Try repair mode:
+   ```bash
+   sudo -u moltbot -i moltbot doctor --repair
+   ```
+
+4. Check available RAM:
+   ```bash
+   free -h
+   ```
+
+### High Memory Usage
+
+Each active channel (Telegram, WhatsApp, Discord, Slack) consumes memory. To reduce:
+
+1. Disable unused channels in `.env`
+2. Increase swap space (see [Low-Memory VPS](./LOW_MEMORY_VPS.md))
+3. Monitor with:
+   ```bash
+   watch -n 1 'free -h && ps aux | grep moltbot'
+   ```
+
+### Service Running But Gateway Unreachable
+
+1. Verify port is listening:
+   ```bash
+   sudo ss -tlnp | grep 18789
+   ```
+
+2. Check firewall rules:
+   ```bash
+   sudo ufw status
+   ```
+
+3. Test localhost access:
+   ```bash
+   curl -v http://localhost:18789
+   ```
+
+4. Check for reverse proxy issues:
+   ```bash
+   # If using nginx/Tailscale, verify X-Forwarded-For headers
+   sudo tail -f /var/log/nginx/access.log  # or relevant proxy logs
+   ```
+
+## Advanced: Manual Service Configuration
+
+The systemd service is generated from `/home/user/moltbot/deploy/moltbot-gateway.service` and deployed by `deploy.sh`. To modify the service:
+
+1. Edit the template: `/home/moltbot/deploy/moltbot-gateway.service`
+2. Re-run deployment: `sudo ./deploy/deploy.sh`
+
+Or manually edit and reload:
+
+```bash
+sudo systemctl edit --full moltbot-gateway
+sudo systemctl daemon-reload
+sudo systemctl restart moltbot-gateway
+```
+
+## Monitoring and Metrics
+
+### Watch Service Health
+
+```bash
+while true; do
+  echo "=== $(date) ==="
+  sudo systemctl status moltbot-gateway | grep -E "Active|memory"
+  echo ""
+  sleep 10
+done
+```
+
+### System Resource Limits
+
+The service is configured with memory limits based on your RAM:
+
+```bash
+# View current limits
+sudo systemctl show moltbot-gateway -p MemoryMax
+
+# View all service properties
+sudo systemctl show moltbot-gateway
+```
+
+### Performance Tuning
+
+The deployment script automatically configures `MemoryMax` and Node.js heap size:
+
+| RAM | MemoryMax | Node.js Heap |
+|-----|-----------|--------------|
+| 2 GB | 1536M | 1024 MB |
+| 4 GB+ | 2G | 1536 MB |
+
+To manually adjust:
+
+```bash
+# Edit the service environment
+sudo nano /etc/systemd/system/moltbot-gateway.service.d/override.conf
+
+# Set custom memory limit
+[Service]
+MemoryMax=2G
+
+# Then reload and restart
+sudo systemctl daemon-reload
+sudo systemctl restart moltbot-gateway
+```
+
+## Updates and Restarts
+
+### Update OpenClaw
+
+```bash
+# Pull the latest deployment scripts
+cd /path/to/moltbot
+git pull origin main
+
+# Run the idempotent deployment (updates npm package, restarts service)
+sudo ./deploy/deploy.sh
+```
+
+### Zero-Downtime Restarts
+
+Graceful restart (allows in-flight requests to complete):
+
+```bash
+sudo systemctl reload moltbot-gateway
+```
+
+Or forceful restart:
+
+```bash
+sudo systemctl restart moltbot-gateway
+```
+
+## Related Documentation
+
+- [Quick Start](./QUICK_START.md) — Initial setup
+- [Configuration Guide](./CONFIGURATION.md) — Environment variables and API keys
+- [Troubleshooting](./TROUBLESHOOTING.md) — Common issues and solutions
+- [Low-Memory VPS](./LOW_MEMORY_VPS.md) — Memory management on limited hardware


### PR DESCRIPTION
Split the monolithic README.md and docs into focused, single-topic files:

New documentation files:
- docs/QUICK_START.md: 5-10 minute deployment guide
- docs/CONFIGURATION.md: AI providers, environment variables, and onboarding
- docs/SERVICE_MANAGEMENT.md: systemctl commands, monitoring, and troubleshooting
- docs/GITHUB_ACTIONS_DEPLOYMENT.md: CI/CD setup and automated deployment
- docs/LOW_MEMORY_VPS.md: Optimization for 2-4 GB RAM systems
- docs/REPOSITORY_STRUCTURE.md: Detailed breakdown of repo files and scripts
- docs/PUBLIC_VS_PRIVATE.md: Repository visibility considerations

Updated files:
- README.md: Simplified to ~160 lines with quick start and links to detailed docs
- docs/README.md: Enhanced navigation hub with categorized quick links and recommended reading paths

Benefits:
- LLMs can read focused docs (~1-3 min per file) instead of one 370-line monolith
- Users can navigate to exactly what they need via clear quick links
- Easier maintenance: changes to one topic don't require updating the entire README
- Better token efficiency for AI processing and context windows

https://claude.ai/code/session_01PiVCntJqovV2uM2vw3c4Fx