### PR TITLE
fix: add sudo pre-flight check and use wildcard sudoers rule

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,12 +59,15 @@ jobs:
 
             echo "=== Moltbot Deployment Started ==="
 
+            DEPLOY_DIR="${{ env.DEPLOY_PATH }}"
+            DEPLOY_SCRIPT="${DEPLOY_DIR}/deploy/deploy.sh"
+
             # Determine action (from workflow_dispatch or default to deploy)
             ACTION="${{ github.event.inputs.action || 'deploy' }}"
             echo "Action: $ACTION"
 
             # Deploy directory is owned by the deploy user (created by setup-server.sh)
-            cd ${{ env.DEPLOY_PATH }}
+            cd "$DEPLOY_DIR"
 
             # Clone or update the repository
             # No sudo — deploy user owns the directory
@@ -80,6 +83,24 @@ jobs:
             # Make scripts executable
             chmod +x deploy/*.sh
 
+            # Verify sudo access before attempting deployment.
+            # If setup-server.sh hasn't been (re-)run since script names
+            # changed, the sudoers rules won't match and sudo will fail
+            # with "a terminal is required to read the password".
+            if [ "$ACTION" = "deploy" ]; then
+              if ! sudo -n -l "$DEPLOY_SCRIPT" >/dev/null 2>&1; then
+                echo ""
+                echo "ERROR: Passwordless sudo is not configured for: $DEPLOY_SCRIPT"
+                echo ""
+                echo "The deploy user's sudoers rules are out of date."
+                echo "SSH into the VPS as root and re-run setup-server.sh:"
+                echo ""
+                echo "  sudo ${DEPLOY_DIR}/deploy/setup-server.sh"
+                echo ""
+                exit 1
+              fi
+            fi
+
             # Disable errexit so diagnostics always run, even on failure
             set +e
 
@@ -87,7 +108,7 @@ jobs:
             case "$ACTION" in
               deploy)
                 echo "Running deployment..."
-                sudo ./deploy/deploy.sh
+                sudo "$DEPLOY_SCRIPT"
                 ;;
               restart)
                 echo "Restarting service..."

--- a/deploy/setup-server.sh
+++ b/deploy/setup-server.sh
@@ -31,8 +31,11 @@ create_deploy_user() {
     su_path=$(command -v su)
 
     # Principle of least privilege: only allow the specific commands needed
-    # for deployment operations. Avoid broad wildcards that could enable
-    # privilege escalation.
+    # for deployment operations.
+    # Note: the deploy user owns /opt/moltbot-deploy (can modify scripts
+    # there), so a wildcard for deploy/*.sh is security-equivalent to
+    # naming individual scripts — but avoids sudoers breakage when deploy
+    # scripts are renamed.
     cat > /etc/sudoers.d/moltbot-deploy << EOF
 # Allow deploy user to manage moltbot service and run deploy scripts
 ${DEPLOY_USER} ALL=(ALL) NOPASSWD: ${systemctl_path} start moltbot-gateway
@@ -43,7 +46,7 @@ ${DEPLOY_USER} ALL=(ALL) NOPASSWD: ${systemctl_path} status moltbot-gateway --no
 ${DEPLOY_USER} ALL=(ALL) NOPASSWD: ${systemctl_path} is-active moltbot-gateway
 ${DEPLOY_USER} ALL=(ALL) NOPASSWD: ${systemctl_path} daemon-reload
 ${DEPLOY_USER} ALL=(ALL) NOPASSWD: ${journalctl_path} -u moltbot-gateway *
-${DEPLOY_USER} ALL=(ALL) NOPASSWD: /opt/moltbot-deploy/deploy/deploy.sh
+${DEPLOY_USER} ALL=(ALL) NOPASSWD: ${DEPLOY_PATH}/deploy/*.sh
 ${DEPLOY_USER} ALL=(ALL) NOPASSWD: ${su_path} - moltbot -c *
 EOF
 


### PR DESCRIPTION
The deploy workflow was failing with "sudo: a terminal is required to
read the password" because the VPS sudoers rules still referenced the
old install.sh/update.sh scripts from before PR #71 merged them into
deploy.sh. The setup-server.sh was never re-run on the VPS to update
the sudoers file.

Changes:
- deploy.yml: add sudo access pre-flight check before running deploy.sh
  with a clear error message telling users to re-run setup-server.sh
- deploy.yml: use absolute path variable for deploy.sh instead of
  relative ./deploy/deploy.sh
- setup-server.sh: use wildcard (deploy/*.sh) in sudoers rule instead
  of a specific script name, so future script renames won't break
  deployments (security-equivalent since deploy user owns the directory)

The user must still SSH into the VPS as root and re-run
setup-server.sh once to apply the updated sudoers rules.

https://claude.ai/code/session_01DcL8oewk77gY8y942JMZUF