### PR TITLE
fix: update ncipollo/release-action to v1.20.0 with correct commit SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
           cat release_notes.md
 
       - name: Create GitHub Release
-        uses: ncipollo/release-action@6c75be85e104c6c3dee4377fb4708d3fa3da04ef # v1.14.0
+        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20.0
         with:
           tag: v${{ steps.next.outputs.next_version }}
           name: v${{ steps.next.outputs.next_version }}


### PR DESCRIPTION
The previous commit SHA (6c75be85e104c6c3dee4377fb4708d3fa3da04ef) was invalid
and causing the release workflow to fail. Updated to the latest version (v1.20.0)
with the correct SHA (b7eabc95ff50cbeeedec83973935c8f306dfcd0b).

https://claude.ai/code/session_01LG9XcacMsxtFKmTy8RghjY