### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: ShellCheck


### PR DESCRIPTION
Potential fix for [https://github.com/Joe-Heffer/deploy-openclaw/security/code-scanning/8](https://github.com/Joe-Heffer/deploy-openclaw/security/code-scanning/8)

Generally, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions in this workflow to the minimum needed. Since the jobs only check out code and run linters, they only require read access to repository contents, and no write permissions or access to other scopes.

The best way to fix this without changing functionality is to add a single `permissions:` block at the top level of the workflow (under the `on:` section and before `jobs:`). This will apply to all jobs that do not specify their own `permissions:`. We can set `contents: read`, which is sufficient for `actions/checkout` and the linters, and does not grant any write permissions. No new imports or dependencies are needed, and no job logic has to change; we only add configuration keys.

Concretely, in `.github/workflows/lint.yml`, between the existing `on:` block (lines 3–8) and the `jobs:` block (line 9), insert:

```yaml
permissions:
  contents: read
```

This preserves existing behavior while restricting the token to read-only repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
