### PR TITLE
Refactor: Separate GitHub Actions linting into dedicated workflow

### DIFF
--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,30 @@
+name: Lint GitHub Actions
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
+  pull_request:
+    paths:
+      - '.github/workflows/**/*.yml'
+      - '.github/workflows/**/*.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Action Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Install actionlint
+        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+      - name: Run actionlint
+        run: ./actionlint -color

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'deploy/**/*.sh'
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '.yamllint'
   pull_request:
+    paths:
+      - 'deploy/**/*.sh'
+      - '**/*.yml'
+      - '**/*.yaml'
+      - '.yamllint'
 
 permissions:
   contents: read
@@ -22,19 +32,6 @@ jobs:
         with:
           scandir: deploy
           severity: warning
-
-  actionlint:
-    name: Action Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
-
-      - name: Install actionlint
-        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-
-      - name: Run actionlint
-        run: ./actionlint -color
 
   yamllint:
     name: YAML Lint


### PR DESCRIPTION
## Summary
This PR refactors the linting workflow by extracting the GitHub Actions linting job into a separate, dedicated workflow file. This improves workflow organization and allows for more granular control over when each linting job runs.

## Key Changes
- **New workflow**: Created `.github/workflows/lint-actions.yml` to handle GitHub Actions linting with `actionlint`
  - Triggers only on changes to workflow files (`.yml` and `.yaml` in `.github/workflows/`)
  - Runs on both push to main and pull requests
  
- **Updated workflow**: Modified `.github/workflows/lint.yml` to remove the `actionlint` job
  - Added path filters to both push and pull_request triggers for shell scripts and YAML files
  - Retained the ShellCheck and yamllint jobs for their respective linting tasks

## Benefits
- **Separation of concerns**: GitHub Actions linting is now isolated from general YAML/shell linting
- **Efficient triggering**: The new workflow only runs when workflow files change, reducing unnecessary job executions
- **Improved maintainability**: Easier to manage and update GitHub Actions-specific linting rules independently

https://claude.ai/code/session_01UgfSZaKkQM9PfzibKsu3bS