### PR TITLE
Use absolute path for deploy script in nightly workflow

### DIFF
--- a/.github/workflows/nightly-update.yml
+++ b/.github/workflows/nightly-update.yml
@@ -77,7 +77,8 @@ jobs:
             chmod +x deploy/*.sh
 
             # Run the deployment (handles restart, health check, and doctor)
-            sudo ./deploy/deploy.sh
+            # Use absolute path to match sudoers configuration
+            sudo ${{ env.DEPLOY_PATH }}/deploy/deploy.sh
 
             echo ""
             echo "=== Nightly Update Complete: ${CURRENT} -> ${LATEST} ==="


### PR DESCRIPTION
## Summary
Updated the nightly deployment workflow to use an absolute path when executing the deploy script with sudo, ensuring compatibility with sudoers configuration requirements.

## Changes
- Modified the deploy script invocation in the nightly-update workflow to use `${{ env.DEPLOY_PATH }}/deploy/deploy.sh` instead of a relative path
- Added a clarifying comment explaining the rationale for using an absolute path

## Details
The sudoers configuration typically requires absolute paths for security reasons. By using the `DEPLOY_PATH` environment variable, we ensure the script path is fully qualified when executed with elevated privileges, preventing potential path resolution issues and improving security compliance.

https://claude.ai/code/session_01PXeqGwck9AhBbgZ6UMEUH3