### PR TITLE
feat: auto-start openclaw-gateway service on first install

### DIFF
--- a/deploy/setup-server.sh
+++ b/deploy/setup-server.sh
@@ -163,6 +163,8 @@ print_next_steps() {
     echo "   - Manual: sudo ${DEPLOY_PATH}/deploy/deploy.sh"
     echo "   - GitHub: Trigger 'Deploy to VPS' workflow"
     echo ""
+    echo "   The deployment will automatically start the openclaw-gateway service."
+    echo ""
     echo "4. Complete openclaw onboarding:"
     echo "   sudo -u openclaw -i openclaw onboard"
     echo ""


### PR DESCRIPTION
Previously, the deployment script would enable the service but not start
it on first install, requiring users to manually run `systemctl start`.
This was inconsistent with the update behavior (which auto-restarts) and
confusing since the service was already enabled (would start on reboot).

Changes:
- deploy.sh: Always start service after deployment, both for first install
  and updates
- deploy.sh: Updated first-install instructions to reflect that service is
  already running
- setup-server.sh: Added note that deployment auto-starts the service

The service is designed to handle missing configuration gracefully (the
.env file is optional in the systemd unit), and users can complete
onboarding while the service is running.

https://claude.ai/code/session_01J8vQaa3FpQND2qBvjqYMmL