### PR TITLE
fix: ensure openclaw binary is found and executable at service start

### DIFF
--- a/deploy/openclaw-gateway.service
+++ b/deploy/openclaw-gateway.service
@@ -20,7 +20,8 @@ Environment=HOMEBREW_CELLAR={{BREW_PREFIX}}/Cellar
 Environment=HOMEBREW_REPOSITORY={{BREW_PREFIX}}/Homebrew
 EnvironmentFile=-{{OPENCLAW_CONFIG_DIR}}/.env
 ExecStartPre=+/bin/sh -c 'for d in {{OPENCLAW_HOME}}/.clawdbot {{OPENCLAW_HOME}}/clawd; do if [ -L "$d" ]; then echo "FATAL: $d is a symlink — refusing to start (security risk)"; exit 1; fi; done && umask 0077 && mkdir -p {{OPENCLAW_HOME}}/.clawdbot {{OPENCLAW_HOME}}/clawd/memory && chown -R {{OPENCLAW_USER}}:{{OPENCLAW_USER}} {{OPENCLAW_HOME}}/.clawdbot {{OPENCLAW_HOME}}/clawd && chmod -R 700 {{OPENCLAW_HOME}}/.clawdbot {{OPENCLAW_HOME}}/clawd'
-ExecStartPre=/bin/sh -c 'echo "openclaw-gateway: pre-start checks..." && test -x {{OPENCLAW_HOME}}/.npm-global/bin/openclaw || { echo "FATAL: {{OPENCLAW_HOME}}/.npm-global/bin/openclaw not found or not executable"; exit 1; } && test -f {{OPENCLAW_CONFIG_DIR}}/.env || echo "WARN: {{OPENCLAW_CONFIG_DIR}}/.env not found, running without env file"'
+ExecStartPre=+/bin/sh -c 'test -e {{OPENCLAW_HOME}}/.npm-global/bin/openclaw && chmod +x {{OPENCLAW_HOME}}/.npm-global/bin/openclaw; target=$(readlink -f {{OPENCLAW_HOME}}/.npm-global/bin/openclaw 2>/dev/null) && [ -f "$target" ] && chmod +x "$target"; true'
+ExecStartPre=/bin/sh -c 'echo "openclaw-gateway: pre-start checks..." && test -x {{OPENCLAW_HOME}}/.npm-global/bin/openclaw || { echo "FATAL: {{OPENCLAW_HOME}}/.npm-global/bin/openclaw not found or not executable"; ls -la {{OPENCLAW_HOME}}/.npm-global/bin/ 2>/dev/null || echo "  (bin directory not found)"; exit 1; } && test -f {{OPENCLAW_CONFIG_DIR}}/.env || echo "WARN: {{OPENCLAW_CONFIG_DIR}}/.env not found, running without env file"'
 ExecStart={{OPENCLAW_HOME}}/.npm-global/bin/openclaw gateway --port {{OPENCLAW_PORT}}
 Restart=always
 RestartSec=10


### PR DESCRIPTION
The systemd ExecStartPre check runs as the openclaw user, but the
deploy script's verification ran as root — masking permission mismatches.
If npm installed the binary under a different prefix, or if the execute
bit was lost (e.g. interrupted install), the service would fail with
"FATAL: .../openclaw not found or not executable" even though deploy
appeared to succeed.

Changes:
- After npm install, search for the binary via the openclaw user's PATH
  if it's not at the expected ~/.npm-global/bin/ location, and create a
  symlink so the service can find it
- Explicitly chmod +x the binary and its symlink target to fix missing
  execute bits from partial installs
- Verify executable permission as the openclaw user (not root) to catch
  permission issues before the service tries to start
- Add a root-privileged ExecStartPre in the service template that
  ensures the binary is executable on every service start
- Improve diagnostic output (ls -la of bin directory) when the binary
  check fails, to aid future debugging

https://claude.ai/code/session_019BoLzRKtcKqbfeK9dA3Bpm