### PR TITLE
feat: integrate ClawHub CLI for easier skill discovery and installation

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -427,6 +427,30 @@ install_openclaw() {
     log_success "OpenClaw version: ${new_version}"
 }
 
+install_clawhub() {
+    log_info "Installing/updating ClawHub CLI..."
+
+    # ClawHub is the official skill registry for OpenClaw.
+    # The CLI lets users search, install, and sync community skills
+    # from https://www.clawhub.ai/ into the workspace skills directory.
+
+    # Check current version if already installed
+    if sudo -u "$OPENCLAW_USER" -i command -v clawhub &>/dev/null; then
+        local current_version
+        current_version=$(sudo -u "$OPENCLAW_USER" -i clawhub --version 2>/dev/null || echo "unknown")
+        log_info "Current ClawHub CLI version: ${current_version}"
+    fi
+
+    # Install/update clawhub as the openclaw user
+    if sudo -u "$OPENCLAW_USER" -i npm install -g clawhub@latest 2>/dev/null; then
+        local new_version
+        new_version=$(sudo -u "$OPENCLAW_USER" -i clawhub --version 2>/dev/null || echo "unknown")
+        log_success "ClawHub CLI version: ${new_version}"
+    else
+        log_warn "ClawHub CLI installation failed — skills can still be installed via 'openclaw onboard'"
+    fi
+}
+
 setup_systemd_service() {
     log_info "Setting up systemd service..."
 
@@ -724,6 +748,10 @@ print_first_install_steps() {
     echo "Configuration directory: ${OPENCLAW_CONFIG_DIR}"
     echo "Data directory: ${OPENCLAW_DATA_DIR}"
     echo ""
+    echo "4. Install skills from ClawHub:"
+    echo "   sudo -u ${OPENCLAW_USER} -i clawhub sync"
+    echo "   Browse skills: https://www.clawhub.ai/skills"
+    echo ""
     echo "Security recommendations:"
     echo "  - Use Tailscale for secure remote access"
     echo "  - Configure DM pairing policies"
@@ -765,6 +793,9 @@ main() {
 
     DEPLOY_PHASE="openclaw installation"
     install_openclaw
+
+    DEPLOY_PHASE="ClawHub CLI installation"
+    install_clawhub
 
     DEPLOY_PHASE="systemd setup"
     setup_systemd_service

--- a/deploy/openclaw.env.template
+++ b/deploy/openclaw.env.template
@@ -114,6 +114,19 @@ OPENCLAW_HOST=0.0.0.0
 # NODE_OPTIONS=--max-old-space-size=512
 
 # =============================================================================
+# Optional: ClawHub (Skill Registry)
+# =============================================================================
+
+# Override the ClawHub registry URL (default: https://www.clawhub.ai)
+# CLAWHUB_REGISTRY=
+
+# Override the directory where skills are installed (default: workspace skills/)
+# CLAWHUB_WORKDIR=
+
+# Disable ClawHub install telemetry
+# CLAWHUB_DISABLE_TELEMETRY=1
+
+# =============================================================================
 # Optional: Voice Configuration (ElevenLabs)
 # =============================================================================
 

--- a/docs/COMMUNITY_APPLICATIONS.md
+++ b/docs/COMMUNITY_APPLICATIONS.md
@@ -1,6 +1,13 @@
 # Community Applications
 
-The OpenClaw community has produced creative applications beyond the core use cases. The [awesome-moltbot-skills](https://github.com/VoltAgent/awesome-moltbot-skills) repository catalogues 700+ skills across 28 categories.
+The OpenClaw community has produced creative applications beyond the core use cases. [ClawHub](https://www.clawhub.ai/skills) is the official skill registry for discovering, installing, and publishing skills. The [awesome-moltbot-skills](https://github.com/VoltAgent/awesome-moltbot-skills) repository also catalogues 700+ skills across 28 categories.
+
+Install skills using the ClawHub CLI (included in the deployment):
+
+```bash
+sudo -u openclaw -i clawhub search "docker"
+sudo -u openclaw -i clawhub sync
+```
 
 ## Notable Community Examples
 
@@ -33,4 +40,4 @@ The OpenClaw community has produced creative applications beyond the core use ca
 | Communication | 26 | Email, messaging, voice |
 | Search and Research | 23 | Brave Search, Exa AI, Kagi, Tavily |
 
-See the full directory at [docs.openclaw.ai/tools/skills](https://docs.openclaw.ai/tools/skills).
+Browse skills at [clawhub.ai/skills](https://www.clawhub.ai/skills) or the [full directory](https://docs.openclaw.ai/tools/skills).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -127,13 +127,35 @@ This interactive wizard guides you through:
 1. **LLM Provider**: Choose Anthropic, OpenAI, or Google Gemini
 2. **Workspace**: Set your workspace name and description
 3. **Channels**: Connect WhatsApp, Telegram, Discord, Slack, etc.
-4. **Skills**: Browse and install community skills from MoltHub
+4. **Skills**: Browse and install community skills from [ClawHub](https://www.clawhub.ai/skills)
 
 The wizard automatically:
 - Generates the auth token for the Gateway UI
 - Creates your `.env` file with your API keys
 - Configures the systemd service
 - Sets up fallback providers if you have multiple keys
+
+## Skills Management (ClawHub)
+
+The deployment installs the [ClawHub](https://www.clawhub.ai/) CLI alongside OpenClaw. ClawHub is the official skill registry — a searchable directory of community skills that extend what your agent can do.
+
+### Browse and Install Skills
+
+```bash
+# Search for skills by keyword (uses vector/embedding search)
+sudo -u openclaw -i clawhub search "home assistant"
+
+# Sync installed skills with the registry (install/update)
+sudo -u openclaw -i clawhub sync
+```
+
+Skills are installed into the workspace `skills/` directory and are picked up by OpenClaw on the next session.
+
+### How Skills Work
+
+A skill is a folder containing a `SKILL.md` file (plus optional supporting files). OpenClaw loads workspace skills from `<workspace>/skills/` automatically. Installed skills are tracked in `.clawhub/lock.json`.
+
+Browse the full directory at [clawhub.ai/skills](https://www.clawhub.ai/skills) or the [community skills catalogue](https://docs.openclaw.ai/tools/skills).
 
 ## Manual Configuration (Without Onboarding)
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -39,7 +39,7 @@ The wizard guides you through:
 - LLM provider selection (Anthropic, OpenAI, or Google Gemini)
 - Workspace setup
 - Channel connections (WhatsApp, Telegram, Discord, Slack, etc.)
-- Skills installation
+- Skills installation (or use the [ClawHub CLI](#install-skills) for more control)
 
 ### Manual Environment Setup (Optional)
 
@@ -89,7 +89,7 @@ For details, see [Gateway UI Setup](./GATEWAY_UI.md).
 ## What's Next?
 
 - **Connect channels**: Configure WhatsApp, Telegram, Discord, Slack, etc. (see [official channel docs](https://docs.openclaw.ai/channels))
-- **Install skills**: Explore the [Skills Marketplace](https://docs.openclaw.ai/tools/skills)
+- **Install skills**: Browse and install from [ClawHub](https://www.clawhub.ai/skills), or use the CLI: `sudo -u openclaw -i clawhub sync`
 - **Secure access**: Use [Tailscale](https://tailscale.com/) instead of exposing the port directly (see [Security Guide](./SECURITY.md))
 - **Monitor service**: View logs with `sudo journalctl -u openclaw-gateway -f`
 - **Run diagnostics**: Execute `sudo -u openclaw -i openclaw doctor`


### PR DESCRIPTION
Install the ClawHub CLI (`npm i -g clawhub`) during deployment so users
can search, install, and sync community skills directly from the
terminal instead of relying solely on the onboarding wizard.

- Add install_clawhub() function to deploy.sh
- Update post-install instructions to mention clawhub sync
- Add Skills Management section to CONFIGURATION.md
- Update QUICK_START.md and COMMUNITY_APPLICATIONS.md references
- Add ClawHub environment variables to env template

Closes #107

https://claude.ai/code/session_016y1LFvqdmaFWLnuy8U5BLB