### PR TITLE
Add credentials directory to backup and deployment scripts

### DIFF
--- a/deploy/backup-agent-memory.sh
+++ b/deploy/backup-agent-memory.sh
@@ -22,6 +22,7 @@ BACKUP_SOURCES=(
     "${OPENCLAW_HOME}/clawd/memory"
     "${OPENCLAW_HOME}/.config/openclaw"
     "${OPENCLAW_HOME}/.local/share/openclaw"
+    "${OPENCLAW_HOME}/.openclaw/credentials"
 )
 
 # Files to exclude for privacy (add patterns here)

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -18,6 +18,7 @@ OPENCLAW_USER="${OPENCLAW_USER:-openclaw}"
 OPENCLAW_HOME="/home/${OPENCLAW_USER}"
 OPENCLAW_CONFIG_DIR="${OPENCLAW_HOME}/.config/openclaw"
 OPENCLAW_DATA_DIR="${OPENCLAW_HOME}/.local/share/openclaw"
+OPENCLAW_CREDENTIALS_DIR="${OPENCLAW_HOME}/.openclaw/credentials"
 NODE_VERSION="22"
 BREW_PREFIX="/home/linuxbrew/.linuxbrew"
 OPENCLAW_PORT="${OPENCLAW_PORT:-18789}"
@@ -191,6 +192,7 @@ create_openclaw_user() {
 
     mkdir -p "${OPENCLAW_HOME}/.clawdbot"
     mkdir -p "${OPENCLAW_HOME}/clawd/memory"
+    mkdir -p "${OPENCLAW_CREDENTIALS_DIR}"
 
     # Restore original umask
     umask "$old_umask"
@@ -198,6 +200,7 @@ create_openclaw_user() {
     # Ensure restrictive permissions on sensitive directories
     chmod 700 "${OPENCLAW_HOME}/.clawdbot"
     chmod 700 "${OPENCLAW_HOME}/clawd"
+    chmod 700 "${OPENCLAW_CREDENTIALS_DIR}"
 
     # Ensure npm prefix is configured.
     # Write .npmrc directly to avoid sudo HOME environment issues


### PR DESCRIPTION
## Summary
This PR adds support for a new credentials directory (`~/.openclaw/credentials`) to both the backup and deployment scripts, ensuring that credentials are properly backed up and the directory is created with appropriate permissions during deployment.

## Changes
- **backup-agent-memory.sh**: Added `${OPENCLAW_HOME}/.openclaw/credentials` to the `BACKUP_SOURCES` array to include credentials in backups
- **deploy.sh**: 
  - Added `OPENCLAW_CREDENTIALS_DIR` variable definition pointing to `${OPENCLAW_HOME}/.openclaw/credentials`
  - Created the credentials directory during user setup in `create_openclaw_user()`
  - Set restrictive permissions (700) on the credentials directory to ensure only the openclaw user can access it

## Implementation Details
The credentials directory is treated as a sensitive directory with the same permission model as `.clawdbot` and `clawd` directories (mode 700), ensuring proper security isolation. This directory is now included in automated backups to prevent credential loss during system updates or migrations.

https://claude.ai/code/session_01Av4hz6axPujk59hbi2BvPX